### PR TITLE
Infinispan server requires Jackson 2.10.0

### DIFF
--- a/integration-tests/camel-infinispan/pom.xml
+++ b/integration-tests/camel-infinispan/pom.xml
@@ -38,6 +38,24 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- We override these to satisfy Infinispan server -->
+    <!-- TODO: this should be removed as soon as Quarkus is upgraded to Jackson 2.10.0 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Quarkus is still using 2.9 so we have to override the versions in the
integration tests. We did the same in the Quarkus Infinispan
integration tests.