### PR TITLE
Update to Quarkus Qpid JMS extension 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         -->
         <camel-quarkus.version>1.0.0-M3</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.11.3</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.13.0</quarkus-qpid-jms.version>
 
         <flatten-plugin.version>1.1.0</flatten-plugin.version>
         <rpkgtests-maven-plugin.version>0.7.0</rpkgtests-maven-plugin.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS extension 0.13.0, released against Quarkus 1.3.0.Final.

Uses Qpid JMS 0.50.0.