### PR TITLE
Add Quarkus Hazelcast Client extension

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -48,6 +48,13 @@
                 <version>${debezium-quarkus-outbox.version}</version>
             </dependency>
 
+            <!-- Hazelcast Client -->
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>quarkus-hazelcast-deployment</artifactId>
+                <version>${quarkus-hazelcast-client.version}</version>
+            </dependency>
+
             <!-- Camel -->
             <!-- This BOM must be the last one as otherwise it will set the dependency versions before the other BOM -->
             <dependency>
@@ -57,7 +64,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -55,6 +55,15 @@
                 <version>${debezium-quarkus-outbox.version}</version>
             </dependency>
 
+            <!-- Hazelcast Client -->
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>quarkus-hazelcast-client-bom</artifactId>
+                <version>${quarkus-hazelcast-client.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Camel extensions -->
             <!-- This BOM must be the last one as otherwise it will set the dependency versions before the other BOM -->
             <dependency>

--- a/integration-tests/hazelcast-client/pom.xml
+++ b/integration-tests/hazelcast-client/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-universe-integration-tests</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-universe-integration-tests-hazelcast-client</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-universe-integration-tests-rpkgtests</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>quarkus-hazelcast-client-integration-tests</artifactId>
+            <version>${quarkus-hazelcast-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>quarkus-hazelcast-client-integration-tests-rpkgtests</artifactId>
+            <version>${quarkus-hazelcast-client.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>com.hazelcast:quarkus-hazelcast-client-integration-tests-rpkgtests</dependency>
+                    </dependenciesToScan>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <dependenciesToScan>
+                                <dependency>com.hazelcast:quarkus-hazelcast-client-integration-tests-rpkgtests</dependency>
+                            </dependenciesToScan>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${quarkus.version}</version>
+                        <executions>
+                            <execution>
+                                <id>native-image</id>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <appArtifact>com.hazelcast:quarkus-hazelcast-client-integration-tests:${quarkus-hazelcast-client.version}</appArtifact>
+                                    <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
+                                    <cleanupServer>true</cleanupServer>
+                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                                    <enableServer>false</enableServer>
+                                    <dumpProxies>false</dumpProxies>
+                                    <graalvmHome>${graalvmHome}</graalvmHome>
+                                    <disableReports>true</disableReports>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
+</project>

--- a/integration-tests/hazelcast-client/src/test/resources/classpathseed
+++ b/integration-tests/hazelcast-client/src/test/resources/classpathseed
@@ -1,0 +1,4 @@
+The purpose of this file is to have a non-empty test-classes directory that will
+be added to the test classpath and used by the Quarkus test extension for storing
+generated classes and other resources that should appear on the classpath during
+the test execution.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -21,6 +21,7 @@
     <modules>
         <module>camel</module>
         <module>kogito</module>
+        <module>hazelcast-client</module>
         <module>rpkgtests</module>
         <module>qpid-jms</module>
         <module>debezium-outbox</module>

--- a/integration-tests/rpkgtests/pom.xml
+++ b/integration-tests/rpkgtests/pom.xml
@@ -22,6 +22,12 @@
             <artifactId>debezium-quarkus-outbox-integration-tests</artifactId>
             <version>${debezium-quarkus-outbox.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>quarkus-hazelcast-client-integration-tests</artifactId>
+            <version>${quarkus-hazelcast-client.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -48,6 +54,11 @@
                                     <groupId>io.debezium</groupId>
                                     <artifactId>debezium-quarkus-outbox-integration-tests</artifactId>
                                     <version>${debezium-quarkus-outbox.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>com.hazelcast</groupId>
+                                    <artifactId>quarkus-hazelcast-client-integration-tests</artifactId>
+                                    <version>${quarkus-hazelcast-client.version}</version>
                                 </testJar>
                             </testJars>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <camel-quarkus.version>1.0.0-M6</camel-quarkus.version>
 
         <quarkus-qpid-jms.version>0.14.0</quarkus-qpid-jms.version>
+        <quarkus-hazelcast-client.version>1.0.0-RC3</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.1.0.Final</debezium-quarkus-outbox.version>
 
         <!-- After upgrading Kogito regenerate the test modules by running


### PR DESCRIPTION
The `1.0.0-RC` version is not released yet (actually, there are no versions released yet). Dropping it to obtain early feedback.

http://github.com/hazelcast/quarkus-hazelcast-client