### PR TITLE
Add openshift extension next to the lubernetes one in code.quarkus.io

### DIFF
--- a/bom/runtime/src/main/resources/extensions-overrides.json
+++ b/bom/runtime/src/main/resources/extensions-overrides.json
@@ -71,6 +71,7 @@
       "metadata": {
         "pinned": [
           "io.quarkus:quarkus-kubernetes",
+          "io.quarkus:quarkus-openshift",
           "io.quarkus:quarkus-smallrye-health",
           "io.quarkus:quarkus-smallrye-fault-tolerance"
         ]


### PR DESCRIPTION
I found it odd UX wise that Kubernetes was pinned up and that the OpenShift one ended up being last. This fix put them together. CC @maxandersen 