### PR TITLE
update to Quarkus Qpid JMS 0.14.0 (plus the Quarkus 1.4.0.Final + Kogito 0.10.0 changes)

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -2,4 +2,4 @@
 set -e
 
 # temporarily disable Kogito tests until 0.9.1 is out
-mvn --settings .github/quarkus-ecosystem-maven-settings.xml clean install -Dquarkus.version=${QUARKUS_VERSION} --projects '!io.quarkus:quarkus-universe-kogito-integration-tests-parent,!io.quarkus:kogito-quarkus-integration-test,!io.quarkus:quarkus-universe-kogito-integration-tests-rpkgtests'
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml clean install -Dquarkus.version=${QUARKUS_VERSION} --projects '!io.quarkus:quarkus-universe-integration-tests-kogito-parent,!io.quarkus:kogito-quarkus-integration-test,!io.quarkus:quarkus-universe-integration-tests-kogito-rpkgtests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,4 +25,4 @@ steps:
     jdkArchitectureOption: 'x64'
     publishJUnitResults: true
     testResultsFiles: '**/surefire-reports/TEST-*.xml'
-    goals: 'package'
+    goals: 'clean package'

--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -34,15 +34,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Camel -->
-            <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom-deployment</artifactId>
-                <version>${camel-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- Qpid JMS -->
             <dependency>
                 <groupId>org.amqphub.quarkus</groupId>
@@ -55,6 +46,16 @@
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-quarkus-outbox-deployment</artifactId>
                 <version>${debezium-quarkus-outbox.version}</version>
+            </dependency>
+
+            <!-- Camel -->
+            <!-- This BOM must be the last one as otherwise it will set the dependency versions before the other BOM -->
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom-deployment</artifactId>
+                <version>${camel-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
         </dependencies>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -124,6 +124,45 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>clean-json-kogito</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-kogito</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <value></value>
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-json-development-mode</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-development-mode</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <value></value>
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -30,11 +30,11 @@
 
             <!-- universe EXTENSIONS -->
 
-            <!-- Camel extensions -->
+            <!-- Kogito -->
             <dependency>
-                <groupId>org.apache.camel.quarkus</groupId>
-                <artifactId>camel-quarkus-bom</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <groupId>org.kie.kogito</groupId>
+                <artifactId>kogito-bom</artifactId>
+                <version>${kogito-quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -53,6 +53,16 @@
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-quarkus-outbox</artifactId>
                 <version>${debezium-quarkus-outbox.version}</version>
+            </dependency>
+
+            <!-- Camel extensions -->
+            <!-- This BOM must be the last one as otherwise it will set the dependency versions before the other BOM -->
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
         </dependencies>

--- a/bom/runtime/src/main/resources/extensions-overrides.json
+++ b/bom/runtime/src/main/resources/extensions-overrides.json
@@ -142,6 +142,13 @@
             "description": "Camel Zip Deflate compression support",
             "group-id": "org.apache.camel.quarkus",
             "artifact-id": "camel-quarkus-zip-deflater"
+        },
+        {
+            "group-id": "io.quarkus",
+            "artifact-id": "quarkus-kogito",
+            "metadata": {
+               "unlisted": true
+            }
         }
     ]
 }

--- a/integration-tests/kogito/kogito-quarkus-integration-test/pom.xml
+++ b/integration-tests/kogito/kogito-quarkus-integration-test/pom.xml
@@ -5,29 +5,17 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-universe-kogito-integration-tests-parent</artifactId>
+        <artifactId>quarkus-universe-integration-tests-kogito-parent</artifactId>
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kogito-quarkus-integration-test</artifactId>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-universe-kogito-integration-tests-rpkgtests</artifactId>
+            <artifactId>quarkus-universe-integration-tests-kogito-rpkgtests</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <exclusions>
@@ -46,132 +34,6 @@
             <groupId>org.kie.kogito</groupId>
             <artifactId>kogito-quarkus-integration-test-rpkgtests</artifactId>
             <version>${kogito-quarkus.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-api</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-internal</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>drools-core</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>drools-compiler</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>drools-decisiontables</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-codegen</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-drools</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-drools-model</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>drools-core-reflective</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>drools-core-static</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>jbpm-bpmn2</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>jbpm-flow</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>jbpm-flow-builder</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-dmn</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-ruleunits</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-bootstrap-core</artifactId>
-            <version>${quarkus.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.sisu</groupId>
-                    <artifactId>org.eclipse.sisu.inject</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-builder</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-development-mode-spi</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
-            <version>${quarkus.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-common</artifactId>
-            <version>${quarkus.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -231,7 +93,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.kie.kogito:kogito-quarkus-integration-test:0.10.0</appArtifact>
+                                    <appArtifact>org.kie.kogito:kogito-quarkus-integration-test:${kogito-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/kogito/kogito-quarkus-integration-test/pom.xml
+++ b/integration-tests/kogito/kogito-quarkus-integration-test/pom.xml
@@ -231,7 +231,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.kie.kogito:kogito-quarkus-integration-test:0.8.0</appArtifact>
+                                    <appArtifact>org.kie.kogito:kogito-quarkus-integration-test:0.10.0</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/kogito/pom.xml
+++ b/integration-tests/kogito/pom.xml
@@ -10,8 +10,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>quarkus-universe-kogito-integration-tests-parent</artifactId>
-    <name>Quarkus universe - Kogito Integration Tests</name>
+    <artifactId>quarkus-universe-integration-tests-kogito-parent</artifactId>
+    <name>Quarkus universe - Integration Tests - Kogito</name>
 
     <packaging>pom</packaging>
 
@@ -73,30 +73,11 @@
         <dependencies>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-kogito-integration-tests-rpkgtests</artifactId>
+                <artifactId>quarkus-universe-integration-tests-kogito-rpkgtests</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom-deployment</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-                <version>${quarkus.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-integration-test-class-transformer</artifactId>
-                <version>${quarkus.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-
 
 </project>

--- a/integration-tests/kogito/rpkgtests/pom.xml
+++ b/integration-tests/kogito/rpkgtests/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.kie.kogito</groupId>
             <artifactId>kogito-quarkus-integration-test</artifactId>
-            <version>0.8.0</version>
+            <version>0.10.0</version>
         </dependency>
     </dependencies>
 
@@ -39,7 +39,7 @@
                                 <testJar>
                                     <groupId>org.kie.kogito</groupId>
                                     <artifactId>kogito-quarkus-integration-test</artifactId>
-                                    <version>0.8.0</version>
+                                    <version>0.10.0</version>
                                 </testJar>
                             </testJars>
                         </configuration>

--- a/integration-tests/kogito/rpkgtests/pom.xml
+++ b/integration-tests/kogito/rpkgtests/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-universe-kogito-integration-tests-parent</artifactId>
+        <artifactId>quarkus-universe-integration-tests-kogito-parent</artifactId>
         <version>999-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-kogito-integration-tests-rpkgtests</artifactId>
+    <artifactId>quarkus-universe-integration-tests-kogito-rpkgtests</artifactId>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
-        <quarkus.version>1.4.0.Final</quarkus.version>
+        <quarkus.version>1.4.1.Final</quarkus.version>
 
         <!-- After upgrading camel-quarkus regenerate the test modules by running
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         -->
         <camel-quarkus.version>1.0.0-M6</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.13.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.14.0</quarkus-qpid-jms.version>
         <debezium-quarkus-outbox.version>1.1.0.Final</debezium-quarkus-outbox.version>
 
         <!-- After upgrading Kogito regenerate the test modules by running

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <quarkus-qpid-jms.version>0.13.0</quarkus-qpid-jms.version>
         <debezium-quarkus-outbox.version>1.1.0.Final</debezium-quarkus-outbox.version>
 
-        <!-- After upgrading camel-quarkus regenerate the test modules by running
+        <!-- After upgrading Kogito regenerate the test modules by running
 
              mvn validate -Pregen-kogito -N
         -->

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
-        <quarkus.version>1.4.0.CR1</quarkus.version>
+        <quarkus.version>1.4.0.Final</quarkus.version>
 
         <!-- After upgrading camel-quarkus regenerate the test modules by running
 
@@ -61,7 +61,7 @@
 
              mvn validate -Pregen-kogito -N
         -->
-        <kogito-quarkus.version>0.8.0</kogito-quarkus.version>
+        <kogito-quarkus.version>0.10.0</kogito-quarkus.version>
 
         <flatten-plugin.version>1.1.0</flatten-plugin.version>
         <rpkgtests-maven-plugin.version>0.7.0</rpkgtests-maven-plugin.version>

--- a/src/kogito-rpkg-templates/run-tests-module-pom.xml
+++ b/src/kogito-rpkg-templates/run-tests-module-pom.xml
@@ -12,18 +12,6 @@
 
     <artifactId>[=runTestsModule.artifactId]</artifactId>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>[=rpkgModule.groupId]</groupId>
@@ -46,132 +34,6 @@
             <groupId>[=testJar.groupId]</groupId>
             <artifactId>[=testJar.artifactId]-rpkgtests</artifactId>
             <version>${kogito-quarkus.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>kogito-api</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>kogito-internal</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>drools-core</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>drools-compiler</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>drools-decisiontables</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>kogito-codegen</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>kogito-drools</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>kogito-drools-model</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>drools-core-reflective</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>drools-core-static</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>jbpm-bpmn2</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>jbpm-flow</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>jbpm-flow-builder</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>kogito-dmn</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>[=testJar.groupId]</groupId>
-            <artifactId>kogito-ruleunits</artifactId>
-            <version>${kogito-quarkus.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-bootstrap-core</artifactId>
-            <version>${quarkus.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.sisu</groupId>
-                    <artifactId>org.eclipse.sisu.inject</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core-deployment</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-builder</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-development-mode-spi</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
-            <version>${quarkus.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-common</artifactId>
-            <version>${quarkus.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -231,7 +93,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>[=testJar.groupId]:[=testJar.artifactId]:[=testJar.versionPlaceholder]</appArtifact>
+                                    <appArtifact>[=testJar.groupId]:[=testJar.artifactId]:${kogito-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.14.0, uses Qpid JMS 0.51.0 against Quarkus 1.4.0.Final.

This PR builds upon the commits for #55 and so incorporates its changes to update to Quarkus 1.4.0.Final and Kogito 0.10.0.