### PR TITLE
update to Quarkus Qpid JMS 0.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         -->
         <camel-quarkus.version>1.0.0-M6</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.14.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.14.1</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.0.0-RC3</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.1.0.Final</debezium-quarkus-outbox.version>
 


### PR DESCRIPTION
update to quarkus-qpid-jms 0.14.1, uses qpid-jms-client 0.51.0 against quarkus 1.4.1.Final