### PR TITLE
Avoid Connection timed out (Read failed) on Azure by setting maven.wa…

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10


### PR DESCRIPTION
…gon.httpconnectionManager.ttlSeconds

@geoand we were struggling with this kind of issues in Camel Quarkus for some time. 

There is some background info in https://issues.apache.org/jira/browse/WAGON-486 and https://issues.apache.org/jira/browse/WAGON-545

I hope azure pipelines is using a Maven version new enough to pick `./mvn/maven.config`