### PR TITLE
update to Quarkus Qpid JMS 0.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         -->
         <camel-quarkus.version>1.0.0-M7</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.14.1</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.15.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.0.0-RC4</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.1.0.Final</debezium-quarkus-outbox.version>
 


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.15.0, uses Qpid JMS 0.51.0 against Quarkus 1.5.0.Final.

(This PR was based on #72 to get the Quarkus 1.5.0.Final update commit since the extension requires it now, and I just left it in...I can rebase and remove it if desired).