### PR TITLE
Update Debezium Outbox latest artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
         <quarkus-qpid-jms.version>0.15.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.0.0-RC4</quarkus-hazelcast-client.version>
-        <debezium-quarkus-outbox.version>1.1.0.Final</debezium-quarkus-outbox.version>
+        <debezium-quarkus-outbox.version>1.2.0.Beta2</debezium-quarkus-outbox.version>
 
         <!-- After upgrading Kogito regenerate the test modules by running
 


### PR DESCRIPTION
In preparation for 1.5.0.Final platform release, this updates the Debezium Outbox extension artifact to the latest release to correct several reported bugs as well as bring the latest available Debezium functionality to users of the Quarkus extension.