### PR TITLE
Upgrade to Quarkus 1.6.0.CR1 and make sure the old versions are excluded from the BOM and extensions.json

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -176,6 +176,102 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>clean-bom-test-maven</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-test-maven</artifactId>\s*<version>1\.5\.0\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-security-test-utils</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-security-test-utils</artifactId>\s*<version>1\.5\.0\.Final</version>\s+(<scope>test</scope>\s+)?</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-vault-spi</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-vault-spi</artifactId>\s*<version>1\.4\.2\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-funqy-knative</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-funqy-knative</artifactId>\s*<version>1\.4\.2\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-integration-tests</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-integration-test-[^/]*</artifactId>\s*<version>1\.5\.0\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-bootstrap-core-test-jar</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-bootstrap-core</artifactId>\s*<version>1\.5\.0\.Final</version>\s+<type>test-jar</type>\s+<scope>test</scope>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -123,6 +123,61 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>clean-bom-kogito</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-kogito[^/]*</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-development-mode</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-development-mode</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-optaplanner</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-optaplanner[^/]*</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -172,7 +172,7 @@
                         </goals>
                         <configuration>
                             <file>${basedir}/.flattened-pom.xml</file>
-                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-kogito</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-kogito[^/]*</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
                             <value />
                             <regexFlags>
                                 <regexFlag>MULTILINE</regexFlag>
@@ -205,6 +205,102 @@
                         <configuration>
                             <file>${basedir}/.flattened-pom.xml</file>
                             <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-optaplanner[^/]*</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-test-maven</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-test-maven</artifactId>\s*<version>1\.5\.0\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-security-test-utils</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-security-test-utils</artifactId>\s*<version>1\.5\.0\.Final</version>\s+(<scope>test</scope>\s+)?</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-vault-spi</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-vault-spi</artifactId>\s*<version>1\.4\.2\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-funqy-knative</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-funqy-knative</artifactId>\s*<version>1\.4\.2\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-integration-tests</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-integration-test-[^/]*</artifactId>\s*<version>1\.5\.0\.Final</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-bootstrap-core-test-jar</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-bootstrap-core</artifactId>\s*<version>1\.5\.0\.Final</version>\s+<type>test-jar</type>\s+<scope>test</scope>\s+</dependency>]]></token>
                             <value />
                             <regexFlags>
                                 <regexFlag>MULTILINE</regexFlag>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -165,7 +165,7 @@
                 <version>1.5.3</version>
                 <executions>
                     <execution>
-                        <id>clean-json-kogito</id>
+                        <id>clean-bom-kogito</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>replace</goal>
@@ -181,7 +181,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>clean-json-development-mode</id>
+                        <id>clean-bom-development-mode</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>replace</goal>
@@ -189,6 +189,22 @@
                         <configuration>
                             <file>${basedir}/.flattened-pom.xml</file>
                             <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-development-mode</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clean-bom-optaplanner</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>io.quarkus</groupId>\s*<artifactId>quarkus-optaplanner[^/]*</artifactId>\s*<version>[^<]+</version>\s+</dependency>]]></token>
                             <value />
                             <regexFlags>
                                 <regexFlag>MULTILINE</regexFlag>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -30,20 +30,20 @@
 
             <!-- universe EXTENSIONS -->
 
-            <!-- Kogito -->
-            <dependency>
-                <groupId>org.kie.kogito</groupId>
-                <artifactId>kogito-bom</artifactId>
-                <version>${kogito-quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- OptaPlanner -->
             <dependency>
                 <groupId>org.optaplanner</groupId>
                 <artifactId>optaplanner-bom</artifactId>
                 <version>${optaplanner-quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Kogito -->
+            <dependency>
+                <groupId>org.kie.kogito</groupId>
+                <artifactId>kogito-bom</artifactId>
+                <version>${kogito-quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/bom/runtime/src/main/resources/extensions-overrides.json
+++ b/bom/runtime/src/main/resources/extensions-overrides.json
@@ -170,6 +170,13 @@
             "metadata": {
                "unlisted": true
             }
+        },
+        {
+            "group-id": "io.quarkus",
+            "artifact-id": "quarkus-funqy-knative",
+            "metadata": {
+               "unlisted": true
+            }
         }
     ]
 }

--- a/bom/runtime/src/main/resources/extensions-overrides.json
+++ b/bom/runtime/src/main/resources/extensions-overrides.json
@@ -149,6 +149,27 @@
             "metadata": {
                "unlisted": true
             }
+        },
+        {
+            "group-id": "io.quarkus",
+            "artifact-id": "quarkus-optaplanner",
+            "metadata": {
+               "unlisted": true
+            }
+        },
+        {
+            "group-id": "io.quarkus",
+            "artifact-id": "quarkus-optaplanner-jackson",
+            "metadata": {
+               "unlisted": true
+            }
+        },
+        {
+            "group-id": "io.quarkus",
+            "artifact-id": "quarkus-optaplanner-jsonb",
+            "metadata": {
+               "unlisted": true
+            }
         }
     ]
 }

--- a/integration-tests/camel/camel-debezium/pom.xml
+++ b/integration-tests/camel/camel-debezium/pom.xml
@@ -10,6 +10,10 @@
 
     <artifactId>quarkus-universe-integration-tests-camel-debezium</artifactId>
 
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
-        <quarkus.version>1.5.1.Final</quarkus.version>
+        <quarkus.version>1.6.0.CR1</quarkus.version>
 
         <!-- After upgrading camel-quarkus regenerate the test modules by running
 


### PR DESCRIPTION
@aloubyansky are there other things I need to exclude? AFAICS the Optaplanner ones are the only ones in 1.5.0.Final.