### PR TITLE
Add some enforcer rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,111 @@
                     <artifactId>rpkgtests-maven-plugin</artifactId>
                     <version>${rpkgtests-maven-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>enforce</id>
+                            <configuration>
+                                <rules>
+                                    <dependencyConvergence/>
+                                    <bannedDependencies>
+                                        <excludes>
+                                            <!-- Use Jakarta artifacts instead of JBoss specific ones -->
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec</exclude>
+                                            <!-- except for these 2 for now as most of the RESTEasy optional artifacts depend on them
+                                            <exclude>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec</exclude>
+                                            <exclude>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec</exclude>
+                                            -->
+                                            <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                                            <exclude>jakarta.ws.rs:jakarta.ws.rs-api</exclude>
+                                            <!-- Exclude javax dependencies in favor of Jakarta -->
+                                            <exclude>javax.activation:activation</exclude>
+                                            <exclude>javax.activation:javax.activation-api</exclude>
+                                            <exclude>javax.annotation:javax.annotation-api</exclude>
+                                            <exclude>javax.enterprise:cdi-api</exclude>
+                                            <exclude>javax.inject:javax.inject</exclude>
+                                            <exclude>javax.json:javax.json-api</exclude>
+                                            <exclude>javax.json.bind:javax.json.bind-api</exclude>
+                                            <exclude>org.glassfish:javax.json</exclude>
+                                            <exclude>org.glassfish:javax.el</exclude>
+                                            <exclude>javax.persistence:javax.persistence-api</exclude>
+                                            <exclude>javax.persistence:persistence-api</exclude>
+                                            <exclude>javax.security.enterprise:javax.security.enterprise-api</exclude>
+                                            <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.servlet:javax.servlet-api</exclude>
+                                            <exclude>javax.transaction:jta</exclude>
+                                            <exclude>javax.transaction:javax.transaction-api</exclude>
+                                            <exclude>javax.validation:validation-api</exclude>
+                                            <exclude>javax.xml.bind:jaxb-api</exclude>
+                                            <exclude>javax.websocket:javax.websocket-api</exclude>
+                                            <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                                            <!-- use our jboss-logmanager -->
+                                            <exclude>org.jboss.logging:jboss-logmanager</exclude>
+                                            <!-- We don't want all the API's in one jar-->
+                                            <exclude>javax:javaee-api</exclude>
+                                            <!-- Prevent incompatible config from coming in -->
+                                            <exclude>org.wildfly.client:wildfly-client-config</exclude>
+                                            <exclude>org.jboss.marshalling:jboss-marshalling-osgi</exclude>
+                                            <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude>
+                                            <!-- The API is packaged by the implementation-->
+                                            <exclude>jakarta.json:jakarta.json-api</exclude>
+                                            <!-- Ensure none of the deps use netty-all. This forces deps to use more fine grained netty artifacts -->
+                                            <exclude>io.netty:netty-all</exclude>
+                                            <!-- Ban Log4J (use org.jboss.logmanager:log4j-jboss-logmanager instead) -->
+                                            <exclude>log4j:log4j</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-api</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                                            <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
+                                            <!-- Ban commons-logging (use org.jboss.logging:commons-logging-jboss-logging instead) -->
+                                            <exclude>commons-logging:commons-logging</exclude>
+                                            <exclude>commons-logging:commons-logging-api</exclude>
+                                            <exclude>org.springframework:spring-jcl</exclude>
+                                            <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                                            <!-- Ban SLF4j implementations (use org.jboss.slf4j:slf4j-jboss-logging instead) -->
+                                            <exclude>org.slf4j:slf4j-simple</exclude>
+                                            <exclude>org.slf4j:slf4j-nop</exclude>
+                                            <exclude>org.slf4j:slf4j-jdk14</exclude>
+                                            <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                            <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <exclude>org.osgi:org.osgi.annotation.versioning</exclude>
+                                            <!-- Ban Spring Dependencies (since we have our own jars)-->
+                                            <exclude>org.springframework:spring-core</exclude>
+                                            <exclude>org.springframework:spring-beans</exclude>
+                                            <exclude>org.springframework:spring-context</exclude>
+                                            <exclude>org.springframework:spring-web</exclude>
+                                            <exclude>org.springframework:spring-webmvc</exclude>
+                                            <exclude>org.springframework.data:spring-data-jpa</exclude>
+                                            <exclude>org.springframework.data:spring-data-commons</exclude>
+                                            <exclude>org.springframework.security:spring-security-core</exclude>
+                                            <exclude>org.springframework.boot:spring-boot</exclude>
+                                            <!-- Ban checker-qual, we don't use Checker Framework -->
+                                            <exclude>org.checkerframework:checker-qual</exclude>
+                                            <!-- We use our own impl here, including this one causes problems-->
+                                            <exclude>org.jboss.resteasy:resteasy-context-propagation</exclude>
+                                        </excludes>
+                                        <includes>
+                                            <!-- this is for REST Assured -->
+                                            <include>jakarta.xml.bind:jakarta.xml.bind-api:*:*:test</include>
+                                        </includes>
+                                    </bannedDependencies>
+                                </rules>
+                            </configuration>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
**Obviously, don't merge because CI will fail.**

Add the dependency convergence rule and also the banned dependencies we
have in Quarkus.

The banned dependencies might not be all relevant but it's a start to
figure out what's going on.

/cc @ppalaga @aloubyansky this doesn't work very well :). I have a lot of errors in quarkus-universe-integration-tests-camel-rpkgtests . I'm not sure the dependency convergence rule makes sense because you probably won't use all the Camel components at once but IMHO that would be good to fix that.

Also the banned dependencies issues should be fixed IMHO. These dependencies were banned for a good reason.