### PR TITLE
Update to Quarkus Qpid JMS 0.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         -->
         <camel-quarkus.version>1.0.0-CR2</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.15.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.16.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.0.0-RC4</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.2.0.Beta2</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.5.0-Alpha4</quarkus-blaze-persistence.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.16.0, uses Qpid JMS 0.52.0 against Quarkus 1.6.0.Final.