### PR TITLE
Upgrade cassandra-client to 1.0.0-alpha2

### DIFF
--- a/integration-tests/cassandra-client/pom.xml
+++ b/integration-tests/cassandra-client/pom.xml
@@ -34,11 +34,9 @@
       <version>${quarkus-cassandra-client.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- Need to force version 4.2, 4.3 has binary incompatibility issues -->
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -143,10 +141,6 @@
                 </goals>
                 <configuration>
                   <groups>native</groups>
-                  <excludes>
-                    <!-- this test is broken in 1.0.0-alpha1 -->
-                    <exclude>**/CassandraMetricsNativeIT.java</exclude>
-                  </excludes>
                   <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-native.xml</summaryFile>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkus-hazelcast-client.version>1.0.0-RC4</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.2.0.Beta2</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.5.0-Alpha4</quarkus-blaze-persistence.version>
-        <quarkus-cassandra-client.version>1.0.0-alpha1</quarkus-cassandra-client.version>
+        <quarkus-cassandra-client.version>1.0.0-alpha2</quarkus-cassandra-client.version>
 
         <!-- After upgrading Kogito regenerate the test modules by running
 


### PR DESCRIPTION
@emmanuelbernard  @gsmet and @aloubyansky:

As discussed in #80, we've just released an alpha2 version of our Cassandra extension.

It brings a few bugfixes reported by the community, and also fixes the issues with Rest Assured and broken integration tests.

We think that this version could be included in Quarkus 1.6 with experimental status. 

@gsmet The quickstart doc is [here](https://github.com/datastax/cassandra-quarkus/blob/master/documentation/src/main/asciidoc/cassandra.adoc), it has been renamed to `cassandra.adoc` as requested.