### PR TITLE
Update to Quarkus Qpid JMS 0.16.1

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -34,13 +34,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Qpid JMS -->
-            <dependency>
-                <groupId>org.amqphub.quarkus</groupId>
-                <artifactId>quarkus-qpid-jms-deployment</artifactId>
-                <version>${quarkus-qpid-jms.version}</version>
-            </dependency>
-
             <!-- Debezium -->
             <dependency>
                 <groupId>io.debezium</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         -->
         <camel-quarkus.version>1.0.0-CR3</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.16.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.16.1</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.0.0-RC4</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.2.0.Beta2</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.5.0-Alpha4</quarkus-blaze-persistence.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.16.1, uses Qpid JMS 0.52.0 against Quarkus 1.6.0.Final.

Just missed getting this PR ready before #86 was merged. I updated the extension bom in 0.16.1 to include the deployment module in line with quarkus-bom changes, as suggested on the mailing lists. This bumps the extension version and removes the superfluous entry from the quarkus-universe-bom-deployment pom already covered by it importing quarkus-universe-bom.