### PR TITLE
Avoid having testcontainers artifacts in the BOM, make Debezium versions consistent

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -314,6 +314,23 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <!-- To be removed in 1.6.1.Final -->
+                    <execution>
+                        <id>clean-bom-antlr</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.antlr</groupId>\s*<artifactId>antlr4</artifactId>\s*<version>4\.8</version>\s+</dependency>]]></token>
+                            <value><![CDATA[<dependency><groupId>org.antlr</groupId><artifactId>antlr4</artifactId><version>4.7.2</version></dependency>]]></value>
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -297,6 +297,23 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <!-- To be removed in 1.7 -->
+                    <execution>
+                        <id>clean-bom-elasticsearch-high-level-client</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.elasticsearch.client</groupId>\s*<artifactId>elasticsearch-rest-high-level-client</artifactId>\s*<version>7\.6\.1</version>\s+</dependency>]]></token>
+                            <value><![CDATA[<dependency><groupId>org.elasticsearch.client</groupId><artifactId>elasticsearch-rest-high-level-client</artifactId><version>7.7.0</version></dependency>]]></value>
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -265,6 +265,22 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>clean-bom-test-containers</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.testcontainers</groupId>\s*<artifactId>[^<]+</artifactId>\s*<version>[^<]+</version>(\s+<type>test-jar</type>)?(\s+<scope>test</scope>)?\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -281,6 +281,22 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>clean-bom-springframework</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.springframework[^<]*</groupId>.*?</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -56,6 +56,18 @@
             </dependency>
             <dependency>
                 <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <classifier>tests</classifier>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <type>test-jar</type>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
                 <artifactId>debezium-dll-parser</artifactId>
                 <version>${debezium.version}</version>
             </dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -64,14 +64,6 @@
                 <artifactId>debezium-embedded</artifactId>
                 <version>${debezium.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <type>pom</type>
-                <scope>import</scope>
-                <version>1.14.3</version>
-            </dependency>
-
 
             <!-- universe EXTENSIONS -->
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -373,6 +373,22 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>clean-bom-springframework</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.springframework[^<]*</groupId>.*?</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -389,6 +389,23 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <!-- To be removed in 1.7 -->
+                    <execution>
+                        <id>clean-bom-elasticsearch-high-level-client</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.elasticsearch.client</groupId>\s*<artifactId>elasticsearch-rest-high-level-client</artifactId>\s*<version>7\.6\.1</version>\s+</dependency>]]></token>
+                            <value><![CDATA[<dependency><groupId>org.elasticsearch.client</groupId><artifactId>elasticsearch-rest-high-level-client</artifactId><version>7.7.0</version></dependency>]]></value>
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -28,6 +28,51 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- Resolve conflicts among platform participants -->
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-api</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-connector-mysql</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-connector-postgres</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-connector-sqlserver</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-core</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-dll-parser</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-embedded</artifactId>
+                <version>${debezium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <type>pom</type>
+                <scope>import</scope>
+                <version>1.14.3</version>
+            </dependency>
+
+
             <!-- universe EXTENSIONS -->
 
             <!-- OptaPlanner -->
@@ -115,7 +160,7 @@
                             <goal>generate-extensions-json</goal>
                         </goals>
                     </execution>
-                    
+
                 </executions>
                 <configuration>
                     <overridesFile>${overridesfile}</overridesFile>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -308,6 +308,22 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>clean-bom-test-containers</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.testcontainers</groupId>\s*<artifactId>[^<]+</artifactId>\s*<version>[^<]+</version>(\s+<type>test-jar</type>)?(\s+<scope>test</scope>)?\s+</dependency>]]></token>
+                            <value />
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -406,6 +406,23 @@
                             </regexFlags>
                         </configuration>
                     </execution>
+                    <!-- To be removed in 1.6.1.Final -->
+                    <execution>
+                        <id>clean-bom-antlr</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <file>${basedir}/.flattened-pom.xml</file>
+                            <token><![CDATA[<dependency>\s*<groupId>org.antlr</groupId>\s*<artifactId>antlr4</artifactId>\s*<version>4\.8</version>\s+</dependency>]]></token>
+                            <value><![CDATA[<dependency><groupId>org.antlr</groupId><artifactId>antlr4</artifactId><version>4.7.2</version></dependency>]]></value>
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                                <regexFlag>DOTALL</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/integration-tests/camel/camel-debezium/pom.xml
+++ b/integration-tests/camel/camel-debezium/pom.xml
@@ -10,10 +10,6 @@
 
     <artifactId>quarkus-universe-integration-tests-camel-debezium</artifactId>
 
-    <properties>
-        <skipTests>true</skipTests>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/camel/camel-kudu/pom.xml
+++ b/integration-tests/camel/camel-kudu/pom.xml
@@ -10,6 +10,10 @@
 
     <artifactId>quarkus-universe-integration-tests-camel-kudu</artifactId>
 
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -49,6 +49,13 @@
                 <artifactId>quarkus-integration-test-class-transformer</artifactId>
                 <version>${quarkus.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <type>pom</type>
+                <scope>import</scope>
+                <version>${testcontainers.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
 
         <quarkus-qpid-jms.version>0.16.1</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.0.0-RC4</quarkus-hazelcast-client.version>
-        <debezium-quarkus-outbox.version>1.2.0.Beta2</debezium-quarkus-outbox.version>
+        <debezium.version>1.2.0.Final</debezium.version>
+        <debezium-quarkus-outbox.version>1.2.0.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.5.0-Alpha4</quarkus-blaze-persistence.version>
         <quarkus-cassandra-client.version>1.0.0-alpha3</quarkus-cassandra-client.version>
 
@@ -66,6 +67,7 @@
         -->
         <kogito-quarkus.version>0.11.1</kogito-quarkus.version>
         <optaplanner-quarkus.version>7.39.0.Final</optaplanner-quarkus.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
 
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <flatten-plugin.version>1.1.0</flatten-plugin.version>


### PR DESCRIPTION
Follow-up of https://github.com/quarkusio/quarkus-platform/pull/88 , includes this commit and a few others.