### PR TITLE
Upgrade cassandra-client to 1.0.0-alpha3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkus-hazelcast-client.version>1.0.0-RC4</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.2.0.Beta2</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.5.0-Alpha4</quarkus-blaze-persistence.version>
-        <quarkus-cassandra-client.version>1.0.0-alpha2</quarkus-cassandra-client.version>
+        <quarkus-cassandra-client.version>1.0.0-alpha3</quarkus-cassandra-client.version>
 
         <!-- After upgrading Kogito regenerate the test modules by running
 


### PR DESCRIPTION
Probably a bit too late for Quarkus 1.6.0 but :-)

This new alpha version simply follows received feedback and turns a few dependencies from optional to mandatory (smallrye-health and smallrye-metrics).

@gsmet I'm not seeing the cassandra.adoc file here:

https://github.com/quarkusio/quarkusio.github.io/tree/develop/_guides

Am I looking at the right place? Thanks!