### PR TITLE
Do not import quarkus-bom-deployment in the platform's deployment BOM

### DIFF
--- a/bom/deployment/pom.xml
+++ b/bom/deployment/pom.xml
@@ -25,15 +25,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Quarkus Core Deployment BOM -->
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom-deployment</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- Debezium -->
             <dependency>
                 <groupId>io.debezium</groupId>


### PR DESCRIPTION
quarkus-bom-deployment simply imports quarkus-bom which is already fully included into platform's runtime BOM.

fyi @gsmet 