### PR TITLE
Update to Quarkus Qpid JMS 0.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         -->
         <camel-quarkus.version>1.0.0-CR3</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.16.1</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.17.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.0.0</quarkus-hazelcast-client.version>
         <debezium.version>1.2.0.Final</debezium.version>
         <debezium-quarkus-outbox.version>1.2.0.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.17.0. Uses Qpid JMS 0.53.0 against Quarkus 1.7.0.Final.