### PR TITLE
Disable camel-quarkus-jpa tests for Quarkus SNAPSHOT builds

### DIFF
--- a/integration-tests/camel/camel-jpa/pom.xml
+++ b/integration-tests/camel/camel-jpa/pom.xml
@@ -78,6 +78,22 @@
 
     <profiles>
         <profile>
+            <!--
+                Disable tests for Quarkus SNAPSHOTs since camel-quarkus-jpa 1.0.0 is not compatible.
+                This can be removed when camel-quarkus supports quarkus >= 1.8.x.
+            -->
+            <id>quarkus-snapshots-disable-tests</id>
+            <activation>
+                <property>
+                    <name>quarkus.version</name>
+                    <value>999-SNAPSHOT</value>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+        <profile>
             <id>native-image</id>
             <activation>
                 <property>


### PR DESCRIPTION
Relates to the latest build failure:

https://github.com/quarkusio/quarkus/issues/8593#issuecomment-678912619

Disabling the problem test until there's a camel-quarkus release that fixes the issue.