### PR TITLE
Minor fixes to the overide for RHBQ 1.7

### DIFF
--- a/bom/src/main/resources/extensions-support-overrides.json
+++ b/bom/src/main/resources/extensions-support-overrides.json
@@ -526,7 +526,7 @@
     },
     {
       "group-id": "io.quarkus",
-      "artifact-id":"quarkus-mysql-client",
+      "artifact-id":"quarkus-reactive-mysql-client",
       "metadata" : {
        "redhat-support" : [
          "tech-preview" ]
@@ -586,6 +586,14 @@
       "metadata" : {
        "redhat-support" : [
          "supported" ]
+       }
+    },
+    {
+      "group-id": "io.quarkus",
+      "artifact-id":"quarkus-resteasy-qute",
+      "metadata" : {
+       "redhat-support" : [
+         "tech-preview" ]
        }
     },
     {


### PR DESCRIPTION
Added missing override for `quarkus-resteasy-qute` and fixed artifact-id for `quarkus-reactive-mysql-client`.