### PR TITLE
Update to Quarkus Qpid JMS 0.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         -->
         <camel-quarkus.version>1.1.0</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.18.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.19.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.1.0</quarkus-hazelcast-client.version>
         <debezium.version>1.2.5.Final</debezium.version>
         <debezium-quarkus-outbox.version>1.2.5.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.19.0. Uses Qpid JMS 0.54.0 against Quarkus 1.9.0.Final.