### PR TITLE
Upgrade to the platform BOM generator 0.0.3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -187,7 +187,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                <version>0.0.2</version>
+                <version>0.0.3</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>


### PR DESCRIPTION
The 0.0.3 release includes only one commit https://github.com/quarkusio/quarkus-platform-bom-generator/commit/01abc25b8dda03b2c1d3ac27fb027a11a5719b8e
It's not fixing/affecting anything that's currently in place in the platform. It's adding support for replacement of `project.version` property when reading the content of `dependencyManagement` of the original platform BOM and upgrades the Quarkus version to 1.9.0.Final.