### PR TITLE
Upgrade to the platform BOM generator 0.0.4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -191,7 +191,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                <version>0.0.3</version>
+                <version>0.0.4</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>


### PR DESCRIPTION
This upgrade fixes an issue that result in two quarkus-bom platform descriptor artifacts of different versions in the generated BOM.
Apparently, Maven request to resolve an artifact descriptor may return a result for an artifact that does not exist. Now the generator will fail in case that happens.
There was also another issue in the generator related to identifying which kind of quarkus core BOM to subtract (quarkus-bom or quarkus-bom-deployment - there are still extensions using quarkus versions in which the deployment BOM was present).