### PR TITLE
Upgrade the platform BOM generator to 0.0.6

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -191,7 +191,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                <version>0.0.5</version>
+                <version>0.0.6</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -191,7 +191,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                <version>0.0.4</version>
+                <version>0.0.5</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>


### PR DESCRIPTION
This version properly propagates transitive dependency exclusions configured in the original BOMs.