### PR TITLE
Update version in pom instead of passing a property

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+# update the version
+mvn versions:set-property -pl . -Dproperty=quarkus.version -DnewVersion=999-SNAPSHOT
+
 # just run all the tests
-mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B -ntp clean install -Dquarkus.version=${QUARKUS_VERSION}
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B -ntp clean install


### PR DESCRIPTION
With the current setup, the version is not propagated to the invoked
tests so we end up using the version in the pom.

/cc @aloubyansky 