### PR TITLE
Bump Kogito 1.2 and OptaPlanner 8.2

### DIFF
--- a/integration-tests/camel/invoked/root/camel-optaplanner/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-optaplanner/pom.xml
@@ -8,6 +8,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <skipTests>true</skipTests> <!-- Disabled because of https://github.com/quarkusio/quarkus-platform/pull/186 -->
+    </properties>
+
     <artifactId>quarkus-universe-integration-tests-camel-optaplanner</artifactId>
 
     <dependencies>

--- a/integration-tests/camel/invoked/root/camel-optaplanner/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-optaplanner/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <properties>
-        <skipTests>true</skipTests> <!-- Disabled because of https://github.com/quarkusio/quarkus-platform/pull/186 -->
+        <skipTests>true</skipTests> <!-- Disabled because of https://github.com/apache/camel-quarkus/issues/2253 -->
     </properties>
 
     <artifactId>quarkus-universe-integration-tests-camel-optaplanner</artifactId>

--- a/integration-tests/kogito/invoked/root/rpkgtests/pom.xml
+++ b/integration-tests/kogito/invoked/root/rpkgtests/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.kie.kogito</groupId>
             <artifactId>kogito-quarkus-integration-test</artifactId>
-            <version>1.1.0.Final</version>
+            <version>1.2.0.Final</version>
         </dependency>
     </dependencies>
 
@@ -39,7 +39,7 @@
                                 <testJar>
                                     <groupId>org.kie.kogito</groupId>
                                     <artifactId>kogito-quarkus-integration-test</artifactId>
-                                    <version>1.1.0.Final</version>
+                                    <version>1.2.0.Final</version>
                                 </testJar>
                             </testJars>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
 
              mvn validate -Pregen-kogito -N
         -->
-        <kogito-quarkus.version>1.1.0.Final</kogito-quarkus.version>
-        <optaplanner-quarkus.version>8.1.0.Final</optaplanner-quarkus.version>
+        <kogito-quarkus.version>1.2.0.Final</kogito-quarkus.version>
+        <optaplanner-quarkus.version>8.2.0.Final</optaplanner-quarkus.version>
         <testcontainers.version>1.15.1</testcontainers.version>
 
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
The 1.2 has been released *while* CR1 got cut. Let's see if it's able to make it without bumping to Quarkus 1.12 explicitly
/cc @mariofusco @cristianonicolai @tiagodolphine @radtriste