### PR TITLE
Skip camel-websocket-jsr356 tests

### DIFF
--- a/integration-tests/camel/invoked/root/camel-websocket-jsr356/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-websocket-jsr356/pom.xml
@@ -10,6 +10,11 @@
 
     <artifactId>quarkus-universe-integration-tests-camel-websocket-jsr356</artifactId>
 
+    <!-- See: https://github.com/apache/camel-quarkus/issues/2262 -->
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Relates to latest build failure with Quarkus SNAPSHOT:

https://github.com/quarkusio/quarkus/issues/8593#issuecomment-780328412