### PR TITLE
Update to Quarkus Qpid JMS 0.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         -->
         <camel-quarkus.version>1.6.0</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.22.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.23.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.1.1</quarkus-hazelcast-client.version>
         <debezium.version>1.3.0.Final</debezium.version>
         <debezium-quarkus-outbox.version>1.4.0.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.23.0, uses Qpid JMS 0.56.0 against Quarkus 1.12.0.Final