### PR TITLE
Fix camel-debezium tests for latest Quarkus SNAPSHOT

### DIFF
--- a/integration-tests/camel/invoked/root/camel-debezium/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-debezium/pom.xml
@@ -42,6 +42,11 @@
             <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-datasource</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-debezium-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>


### PR DESCRIPTION
Relates to build reported failure https://github.com/quarkusio/quarkus/issues/8593#issuecomment-787669126.

Not sure where `quarkus-datasource` comes into the picture here. I don't think these tests are doing anything with the Quarkus datasource stuff. Without the dependency there's an NCDFE:

```
Caused by: java.lang.NoClassDefFoundError: io/quarkus/datasource/runtime/DatabaseKindConverter
	at io.quarkus.runtime.generated.Config.<clinit>(Config.zig:346)
	at io.quarkus.runner.ApplicationImpl.<clinit>(ApplicationImpl.zig:57)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:398)
	at io.quarkus.runner.bootstrap.StartupActionImpl.run(StartupActionImpl.java:196)
	at io.quarkus.test.junit.QuarkusTestExtension.doJavaStart(QuarkusTestExtension.java:331)
	at io.quarkus.test.junit.QuarkusTestExtension.ensureStarted(QuarkusTestExtension.java:638)
	at io.quarkus.test.junit.QuarkusTestExtension.beforeAll(QuarkusTestExtension.java:684)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeBeforeAllCallbacks$8(ClassBasedTestDescriptor.java:368)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeBeforeAllCallbacks(ClassBasedTestDescriptor.java:368)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.before(ClassBasedTestDescriptor.java:192)
	... 33 more
```

