### PR TITLE
Upgrade to quarkus-platform-bom-maven-plugin 0.0.8

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -191,7 +191,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                <version>0.0.6</version>
+                <version>0.0.8</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -13,15 +13,15 @@
     <name>Quarkus universe - Parent pom</name>
     <version>999-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <description>Quarkus universe aggregates extensions from Quarkus Core and those developed by the community into a single compatible and versioned set that application developers can reference from their applications to align the dependency versions</description>
-    <url>https://github.com/quarkusio/quarkus-universe</url>
+    <description>Quarkus Universe platform aggregates extensions from Quarkus Core and those developed by the community into a single compatible and versioned set that application developers can reference from their applications to align the dependency versions</description>
+    <url>https://github.com/quarkusio/quarkus-platform</url>
 
     <developers>
         <developer>
             <id>quarkus</id>
             <name>Quarkus Community</name>
-            <organization>Red Hat</organization>
-            <organizationUrl>http://www.redhat.com</organizationUrl>
+            <organization>Quarkus</organization>
+            <organizationUrl>https://quarkus.io</organizationUrl>
         </developer>
     </developers>
 


### PR DESCRIPTION
This version properly orders the platform descriptors in the dependencyManagement section of the BOM, i.e. according to their hierarchy instead of alphabetically along with the rest of the dependencies.