### PR TITLE
Temporarily disable camel-grpc tests

### DIFF
--- a/integration-tests/camel/invoked/root/camel-grpc/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-grpc/pom.xml
@@ -78,6 +78,21 @@
 
     <profiles>
         <profile>
+            <!--
+                This can be removed when camel-quarkus supports quarkus >= 1.14.x.
+            -->
+            <id>quarkus-snapshots-disable-tests</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_WORKFLOW</name>
+                    <value>Quarkus ecosystem CI</value>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+        <profile>
             <id>native-image</id>
             <activation>
                 <property>


### PR DESCRIPTION
Relates to latest Quarkus SNAPSHOT build failure:

https://github.com/quarkusio/quarkus/issues/8593#issuecomment-804649551

I'd prefer to only disable these tests on the SNAPSHOT builds, hence the profile hack. Not sure if there's a better way of doing it?