### PR TITLE
Update to Quarkus Qpid JMS 0.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         -->
         <camel-quarkus.version>1.7.0</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.23.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.24.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.1.1</quarkus-hazelcast-client.version>
         <debezium.version>1.3.0.Final</debezium.version>
         <debezium-quarkus-outbox.version>1.4.0.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.24.0, uses Qpid JMS 0.57.0 against Quarkus 1.13.0.Final