### PR TITLE
Upgrade to Camel Quarkus 1.8.0

### DIFF
--- a/integration-tests/camel/invoked/root/camel-debezium/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-debezium/pom.xml
@@ -42,11 +42,6 @@
             <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-datasource</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-debezium-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>

--- a/integration-tests/camel/invoked/root/camel-freemarker/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-freemarker/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-pg-replication-slot</artifactId>
+    <artifactId>quarkus-universe-integration-tests-camel-freemarker</artifactId>
 
     <dependencies>
         <dependency>
@@ -25,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot</artifactId>
+            <artifactId>camel-quarkus-integration-test-freemarker</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-freemarker-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-freemarker-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -91,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-freemarker-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -121,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-freemarker:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-grpc/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-grpc/pom.xml
@@ -78,21 +78,6 @@
 
     <profiles>
         <profile>
-            <!--
-                This can be removed when camel-quarkus supports quarkus >= 1.14.x.
-            -->
-            <id>quarkus-snapshots-disable-tests</id>
-            <activation>
-                <property>
-                    <name>env.GITHUB_WORKFLOW</name>
-                    <value>Quarkus ecosystem CI</value>
-                </property>
-            </activation>
-            <properties>
-                <skipTests>true</skipTests>
-            </properties>
-        </profile>
-        <profile>
             <id>native-image</id>
             <activation>
                 <property>

--- a/integration-tests/camel/invoked/root/camel-hl7/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-hl7/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-aws</artifactId>
+    <artifactId>quarkus-universe-integration-tests-camel-hl7</artifactId>
 
     <dependencies>
         <dependency>
@@ -25,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-aws</artifactId>
+            <artifactId>camel-quarkus-integration-test-hl7</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-aws-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-hl7-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-aws-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-hl7-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -91,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-aws-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-hl7-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -121,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-aws:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-hl7:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-js-dsl/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-js-dsl/pom.xml
@@ -8,12 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-websocket-jsr356</artifactId>
-
-    <!-- See: https://github.com/apache/camel-quarkus/issues/2262 -->
-    <properties>
-        <skipTests>true</skipTests>
-    </properties>
+    <artifactId>quarkus-universe-integration-tests-camel-js-dsl</artifactId>
 
     <dependencies>
         <dependency>
@@ -30,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-websocket-jsr356</artifactId>
+            <artifactId>camel-quarkus-integration-test-js-dsl</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-websocket-jsr356-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-js-dsl-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -70,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-websocket-jsr356-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -96,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-websocket-jsr356-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -126,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-websocket-jsr356:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-lra/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-lra/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-pg-replication-slot</artifactId>
+    <artifactId>quarkus-universe-integration-tests-camel-lra</artifactId>
 
     <dependencies>
         <dependency>
@@ -25,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot</artifactId>
+            <artifactId>camel-quarkus-integration-test-lra</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-lra-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-lra-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -91,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-lra-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -121,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-lra:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-main-yaml/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-main-yaml/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-azure</artifactId>
+    <artifactId>quarkus-universe-integration-tests-camel-main-yaml</artifactId>
 
     <dependencies>
         <dependency>
@@ -25,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-azure</artifactId>
+            <artifactId>camel-quarkus-integration-test-main-yaml</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-azure-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-main-yaml-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-azure-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-yaml-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -91,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-azure-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-yaml-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -121,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-azure:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-yaml:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-nitrite/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-nitrite/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-send-dynamic-http</artifactId>
+    <artifactId>quarkus-universe-integration-tests-camel-nitrite</artifactId>
 
     <dependencies>
         <dependency>
@@ -25,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-send-dynamic-http</artifactId>
+            <artifactId>camel-quarkus-integration-test-nitrite</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-send-dynamic-http-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-nitrite-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-send-dynamic-http-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-nitrite-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -91,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-send-dynamic-http-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-nitrite-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -121,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-send-dynamic-http:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-nitrite:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-optaplanner/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-optaplanner/pom.xml
@@ -8,10 +8,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <skipTests>true</skipTests> <!-- Disabled because of https://github.com/apache/camel-quarkus/issues/2253 -->
-    </properties>
-
     <artifactId>quarkus-universe-integration-tests-camel-optaplanner</artifactId>
 
     <dependencies>

--- a/integration-tests/camel/invoked/root/camel-paho-mqtt5/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-paho-mqtt5/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-pg-replication-slot</artifactId>
+    <artifactId>quarkus-universe-integration-tests-camel-paho-mqtt5</artifactId>
 
     <dependencies>
         <dependency>
@@ -25,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot</artifactId>
+            <artifactId>camel-quarkus-integration-test-paho-mqtt5</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-paho-mqtt5-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-paho-mqtt5-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -91,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-paho-mqtt5-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -121,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-paho-mqtt5:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-splunk/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-splunk/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-universe-integration-tests-camel-pg-replication-slot</artifactId>
+    <artifactId>quarkus-universe-integration-tests-camel-splunk</artifactId>
 
     <dependencies>
         <dependency>
@@ -25,12 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot</artifactId>
+            <artifactId>camel-quarkus-integration-test-splunk</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-pg-replication-slot-rpkgtests</artifactId>
+            <artifactId>camel-quarkus-integration-test-splunk-rpkgtests</artifactId>
             <version>${camel-quarkus.version}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>
-                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                        <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk-rpkgtests</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
                         <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
@@ -91,7 +91,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <dependenciesToScan>
-                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot-rpkgtests</dependency>
+                                <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk-rpkgtests</dependency>
                             </dependenciesToScan>
                         </configuration>
                         <executions>
@@ -121,7 +121,7 @@
                                     <goal>native-image</goal>
                                 </goals>
                                 <configuration>
-                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot:${camel-quarkus.version}</appArtifact>
+                                    <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk:${camel-quarkus.version}</appArtifact>
                                     <reportErrorsAtRuntime>false</reportErrorsAtRuntime>
                                     <cleanupServer>true</cleanupServer>
                                     <enableHttpUrlHandler>true</enableHttpUrlHandler>

--- a/integration-tests/camel/invoked/root/camel-sql/pom.xml
+++ b/integration-tests/camel/invoked/root/camel-sql/pom.xml
@@ -10,11 +10,6 @@
 
     <artifactId>quarkus-universe-integration-tests-camel-sql</artifactId>
 
-    <!-- See: https://github.com/apache/camel-quarkus/issues/2296 -->
-    <properties>
-        <skipTests>true</skipTests>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/camel/invoked/root/pom.xml
+++ b/integration-tests/camel/invoked/root/pom.xml
@@ -35,10 +35,8 @@
         <module>camel-atlasmap</module>
         <module>camel-avro</module>
         <module>camel-avro-rpc</module>
-        <module>camel-aws</module>
         <module>camel-aws2</module>
         <module>camel-aws2-grouped</module>
-        <module>camel-azure</module>
         <module>camel-azure-eventhubs</module>
         <module>camel-azure-storage-blob</module>
         <module>camel-azure-storage-queue</module>
@@ -72,6 +70,7 @@
         <module>camel-flatpack</module>
         <module>camel-fop</module>
         <module>camel-foundation</module>
+        <module>camel-freemarker</module>
         <module>camel-ftp</module>
         <module>camel-geocoder</module>
         <module>camel-git</module>
@@ -84,6 +83,7 @@
         <module>camel-grpc</module>
         <module>camel-hazelcast</module>
         <module>camel-headersmap</module>
+        <module>camel-hl7</module>
         <module>camel-http</module>
         <module>camel-hystrix</module>
         <module>camel-infinispan</module>
@@ -95,6 +95,7 @@
         <module>camel-jira</module>
         <module>camel-jolt</module>
         <module>camel-jpa</module>
+        <module>camel-js-dsl</module>
         <module>camel-jsch</module>
         <module>camel-jslt</module>
         <module>camel-json-validator</module>
@@ -107,6 +108,7 @@
         <module>camel-kubernetes</module>
         <module>camel-kudu</module>
         <module>camel-leveldb</module>
+        <module>camel-lra</module>
         <module>camel-lumberjack</module>
         <module>camel-mail</module>
         <module>camel-main</module>
@@ -116,6 +118,7 @@
         <module>camel-main-discovery-disabled</module>
         <module>camel-main-xml-io</module>
         <module>camel-main-xml-jaxb</module>
+        <module>camel-main-yaml</module>
         <module>camel-messaging</module>
         <module>camel-micrometer</module>
         <module>camel-microprofile</module>
@@ -126,12 +129,14 @@
         <module>camel-nagios</module>
         <module>camel-nats</module>
         <module>camel-netty</module>
+        <module>camel-nitrite</module>
         <module>camel-nsq</module>
         <module>camel-oaipmh</module>
         <module>camel-olingo4</module>
         <module>camel-openapi-java</module>
         <module>camel-opentracing</module>
         <module>camel-optaplanner</module>
+        <module>camel-paho-mqtt5</module>
         <module>camel-pdf</module>
         <module>camel-pg-replication-slot</module>
         <module>camel-pgevent</module>
@@ -149,7 +154,6 @@
         <module>camel-saga</module>
         <module>camel-salesforce</module>
         <module>camel-sap-netweaver</module>
-        <module>camel-send-dynamic-http</module>
         <module>camel-servicenow</module>
         <module>camel-servlet</module>
         <module>camel-shiro</module>
@@ -157,6 +161,7 @@
         <module>camel-smallrye-reactive-messaging</module>
         <module>camel-soap</module>
         <module>camel-solr</module>
+        <module>camel-splunk</module>
         <module>camel-spring-rabbitmq</module>
         <module>camel-sql</module>
         <module>camel-stax</module>
@@ -175,7 +180,6 @@
         <module>camel-vertx-kafka</module>
         <module>camel-vertx-websocket</module>
         <module>camel-weather</module>
-        <module>camel-websocket-jsr356</module>
         <module>camel-xml</module>
         <module>camel-xmlsecurity</module>
         <module>camel-xstream</module>

--- a/integration-tests/camel/invoked/root/rpkgtests/pom.xml
+++ b/integration-tests/camel/invoked/root/rpkgtests/pom.xml
@@ -51,22 +51,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-aws</artifactId>
-            <version>${camel-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-aws2</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-aws2-grouped</artifactId>
-            <version>${camel-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-azure</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
@@ -236,6 +226,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-freemarker</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-ftp</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
@@ -296,6 +291,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-hl7</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-http</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
@@ -347,6 +347,11 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-jpa</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-js-dsl</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
@@ -411,6 +416,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-lra</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-lumberjack</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
@@ -452,6 +462,11 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-main-xml-jaxb</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-main-yaml</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
@@ -506,6 +521,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-nitrite</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-nsq</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
@@ -532,6 +552,11 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-optaplanner</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-paho-mqtt5</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
@@ -621,11 +646,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-send-dynamic-http</artifactId>
-            <version>${camel-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-servicenow</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
@@ -657,6 +677,11 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-solr</artifactId>
+            <version>${camel-quarkus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-splunk</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
         <dependency>
@@ -751,11 +776,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-integration-test-websocket-jsr356</artifactId>
-            <version>${camel-quarkus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-xml</artifactId>
             <version>${camel-quarkus.version}</version>
         </dependency>
@@ -833,22 +853,12 @@
                                 </testJar>
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
-                                    <artifactId>camel-quarkus-integration-test-aws</artifactId>
-                                    <version>${camel-quarkus.version}</version>
-                                </testJar>
-                                <testJar>
-                                    <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-aws2</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-aws2-grouped</artifactId>
-                                    <version>${camel-quarkus.version}</version>
-                                </testJar>
-                                <testJar>
-                                    <groupId>org.apache.camel.quarkus</groupId>
-                                    <artifactId>camel-quarkus-integration-test-azure</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
                                 <testJar>
@@ -1018,6 +1028,11 @@
                                 </testJar>
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-freemarker</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-ftp</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
@@ -1078,6 +1093,11 @@
                                 </testJar>
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-hl7</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-http</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
@@ -1129,6 +1149,11 @@
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-jpa</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-js-dsl</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
                                 <testJar>
@@ -1193,6 +1218,11 @@
                                 </testJar>
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-lra</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-lumberjack</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
@@ -1234,6 +1264,11 @@
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-main-xml-jaxb</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-main-yaml</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
                                 <testJar>
@@ -1288,6 +1323,11 @@
                                 </testJar>
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-nitrite</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-nsq</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
@@ -1314,6 +1354,11 @@
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-optaplanner</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-paho-mqtt5</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
                                 <testJar>
@@ -1403,11 +1448,6 @@
                                 </testJar>
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
-                                    <artifactId>camel-quarkus-integration-test-send-dynamic-http</artifactId>
-                                    <version>${camel-quarkus.version}</version>
-                                </testJar>
-                                <testJar>
-                                    <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-servicenow</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
@@ -1439,6 +1479,11 @@
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-solr</artifactId>
+                                    <version>${camel-quarkus.version}</version>
+                                </testJar>
+                                <testJar>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-integration-test-splunk</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
                                 <testJar>
@@ -1529,11 +1574,6 @@
                                 <testJar>
                                     <groupId>org.apache.camel.quarkus</groupId>
                                     <artifactId>camel-quarkus-integration-test-weather</artifactId>
-                                    <version>${camel-quarkus.version}</version>
-                                </testJar>
-                                <testJar>
-                                    <groupId>org.apache.camel.quarkus</groupId>
-                                    <artifactId>camel-quarkus-integration-test-websocket-jsr356</artifactId>
                                     <version>${camel-quarkus.version}</version>
                                 </testJar>
                                 <testJar>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
              mvn validate -Pregen-camel -N
         -->
-        <camel-quarkus.version>1.7.0</camel-quarkus.version>
+        <camel-quarkus.version>1.8.0</camel-quarkus.version>
 
         <quarkus-qpid-jms.version>0.24.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.1.1</quarkus-hazelcast-client.version>


### PR DESCRIPTION
This will probably fail now, because Camel Quarkus artifacts are not synced to Central yet. They should be there in a couple of hours.