### PR TITLE
Upgrade the BOM generator to 0.0.10

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -176,7 +176,6 @@
                 <artifactId>blaze-persistence-integration-hibernate-5.4</artifactId>
                 <version>${quarkus-blaze-persistence.version}</version>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
     <build>
@@ -184,7 +183,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.10</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>

--- a/descriptor/pom.xml
+++ b/descriptor/pom.xml
@@ -26,13 +26,13 @@
         <plugins>
             <plugin>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-platform-descriptor-json-plugin</artifactId>
-                <version>${quarkus.version}</version>
+                <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
+                <version>0.0.10</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>generate-platform-descriptor-json</goal>
+                            <goal>generate-platform-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -40,6 +40,20 @@
                     <bomArtifactId>quarkus-universe-bom</bomArtifactId>
                     <overridesFile>${overridesfile}</overridesFile>
                     <skipCategoryCheck>true</skipCategoryCheck>
+                    <processGroupIds>
+                        <groupId>org.kie.kogito</groupId>
+                        <groupId>org.optaplanner</groupId>
+                        <groupId>com.blazebit</groupId>
+                        <groupId>io.quarkiverse.freemarker</groupId>
+                        <groupId>io.quarkiverse.googlecloudservices</groupId>
+                        <groupId>io.quarkiverse.minio</groupId>
+                        <groupId>io.quarkus</groupId>
+                        <groupId>org.apache.camel.quarkus</groupId>
+                        <groupId>io.debezium</groupId>
+                        <groupId>org.amqphub.quarkus</groupId>
+                        <groupId>com.datastax.oss.quarkus</groupId>
+                        <groupId>com.hazelcast</groupId>
+                    </processGroupIds>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Significantly reduces the time needed to generate the BOM.
It also configures explicitly the groupIds of the artifacts that should be checked for containing Quarkus extensions during the JSON descriptor generation.