### PR TITLE
Upgrade to the bom generator 0.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,33 +101,39 @@ by navigating to the desired test module and using `mvn` commands they typically
 
 The platform is currently configured in the root POM file under the `platformConfig` element of the `io.quarkus:quarkus-platform-bom-maven-plugin` configuration.
 
-### The all-inclusive BOM
+### Release configuration
 
-The is the BOM that contains the dependency constraints of all the platform members, in Quarkus 1.x it is known as the `quarkus-universe-bom`. Its cordinates can be configured using the `bom` element, e.g.
+The platform release configuration is expressed under the `release` element, e.g.
+```xml
+  <platformConfig>
+    <!-- the platform release info -->
+    <release>
+      <!-- the platform (dev stack) key (if not specified, defaults to the root project's groudId) -->
+      <platformKey>${project.groupId}</platformKey>
+      <!-- platform stream id, representing the flow of backward compatible releases
+           (if not specified, defaults to the project's major.minor platform version) -->
+      <stream>2.0</stream>
+      <!-- platform (comparable) version, must be unique in the scope of the stream
+           (if not specified, defaults to the micro version of the complete platform version) -->
+      <version>0</version>
+    </release>
+```
+
+### The universal platform
+
+This is the BOM that contains the dependency version constraints of all the platform members. In Quarkus 1.x it is known as the `quarkus-universe-bom`.
+Its cordinates can be configured using the `bom` element, e.g.
 
 ```xml
   <platformConfig>
-    <!-- coordinates of the generated all-inclusive platform BOM -->
-    <bom>io.quarkus:quarkus-universe-bom:${project.version}</bom>
-    <!-- whether to skip installation of the all-inclusive platform BOM -->
-    <skipInstall>false</skipInstall>
+    <universal>
+      <!-- coordinates of the generated all-inclusive platform BOM -->
+      <bom>io.quarkus:quarkus-universe-bom:${project.version}</bom>
+      <!-- whether to skip installation of the all-inclusive platform BOM -->
+      <skipInstall>false</skipInstall>
+    </universal>
 ```
-`skipInstall` element can be used to exclude the all-inclusive BOM from the artifacts to be installed and deployed.
-
-### Release configuration
-
-The platform release configuration is expressed under the `platformRelease` element, e.g.
-```xml
-  <!-- the platform release info -->
-  <platformRelease>
-    <!-- the platform (dev stack) key (if not specified, defaults to the root project's groudId) -->
-    <platformKey>${project.groupId}</platformKey>
-    <!-- platform stream id, representing the flow of backward compatible releases (if not specified, defaults to the project's major.minor platform version) -->
-    <stream>2.0</stream>
-    <!-- platform (comparable) version, must be unique in the scope of the stream (if not specified, defaults to the micro version of the complete platform version) -->
-    <version>0</version>
-  </platformRelease>
-```
+The `skipInstall` element can be used to exclude the all-inclusive BOM from the artifacts to be installed and deployed.
 
 ### Quarkus core configuration
 

--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -31,7 +31,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-          <version>0.0.16</version>
+          <version>0.0.17</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <kogito-quarkus.version>1.6.0.Final</kogito-quarkus.version>
         <optaplanner-quarkus.version>8.6.0.Final</optaplanner-quarkus.version>
 
+        <quarkus-platform-bom-generator.version>0.0.17</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <rpkgtests-maven-plugin.version>0.8.0</rpkgtests-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
@@ -135,7 +136,7 @@
                 <plugin>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-                    <version>0.0.16</version>
+                    <version>${quarkus-platform-bom-generator.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -163,12 +164,8 @@
                 </executions>
                 <configuration>
                     <platformConfig>
-                        <!-- coordinates of the generated all-inclusive platform BOM -->
-                        <bom>io.quarkus:quarkus-universe-bom:${project.version}</bom>
-                        <!-- whether to skip installation of the all-inclusive platform BOM -->
-                        <skipInstall>false</skipInstall>
                         <!-- the platform release info -->
-                        <platformRelease>
+                        <release>
                             <!--
                                 |  the platform (dev stack) key (if not specified, defaults to the root project's groudId)
                             -->
@@ -181,7 +178,14 @@
                                 | platform (comparable) version, must be unique in the scope of the stream, (if not specified, defaults to the micro version of the complete platform version)
                             -->
                             <!-- version>0</version> -->
-                        </platformRelease>
+                        </release>
+                        <!-- Universal / all-inclusive platform -->
+                        <universal>
+                            <!-- coordinates of the generated all-inclusive platform BOM -->
+                            <bom>io.quarkus:quarkus-universe-bom:${project.version}</bom>
+                            <!-- whether to skip installation of the all-inclusive platform BOM -->
+                            <skipInstall>false</skipInstall>
+                        </universal>
                         <!-- Quarkus core -->
                         <core>
                             <name>Core</name>


### PR DESCRIPTION
Fixes the default platform release info generation, specifically the default stream and version for platform versions with qualifiers.