### PR TITLE
Updated to the BOM generator 0.0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,11 @@ Platform members are configured under the `member` element, e.g.
       <enabled>true</enabled>                                                      <!-- 3 -->
       <release>
         <next>${project.groupId}:quarkus-optaplanner-bom:${project.version}</next> <!-- 4 -->
+        <!-- updated automatically -->
+        <lastDetectedBomUpdate>io.quarkus.platform:quarkus-optaplanner-bom:2.0.0.Final</lastDetectedBomUpdate> <!-- 5 -->
       </release>
-      <defaultTestConfig>                                                          <!-- 5 -->
-        <skip>false</skip>                                                         <!-- 6 -->
+      <defaultTestConfig>                                                          <!-- 6 -->
+        <skip>false</skip>                                                         <!-- 7 -->
       </defaultTestConfig>
       <tests>
         <test> <!-- 7 -->
@@ -178,6 +180,8 @@ Platform members are configured under the `member` element, e.g.
 1. The original member BOM coordinates representing members build and run times classpath constraints
 1. Whether the member actually participates in the platform build or not (if a member is disabled, the rest of its configuration will be ignored)
 1. The coordinates under which the generated member platform BOM should be installed and deployed
+1. The BOM generator detects whether the generated member BOM has changed since the previous release and records the value of the last release in which the BOM
+has actually changed. The value of this element is meant to be updated during the release process by the tool itself in case the BOM has actually changed.
 1. The default configuration options for all the tests of the member
 1. Can be used to skip all the member tests (unless explicitly overriden in a test config)
 1. Specific test configuration will reference a Maven test jar artifact containing the tests that should be run as part of the platform's IT

--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -22,8 +22,8 @@
   <properties>
     <platform.key>io.quarkus.platform</platform.key>
     <platform.stream>999-SNAPSHOT</platform.stream>
-    <main.bom.version>999-SNAPSHOT</main.bom.version>
     <platform.release>0</platform.release>
+    <universal.bom.version>999-SNAPSHOT</universal.bom.version>
   </properties>
   <build>
     <pluginManagement>
@@ -31,7 +31,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-          <version>0.0.17</version>
+          <version>0.0.18</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
@@ -11,6 +11,9 @@
   <artifactId>quarkus-blaze-persistence-bom-quarkus-platform-descriptor</artifactId>
   <packaging>pom</packaging>
   <name>Quarkus Platform - Blaze-Persistence - Quarkus Platform Descriptor</name>
+  <properties>
+    <member.last-bom-update>io.quarkus.platform:quarkus-blaze-persistence-bom:999-SNAPSHOT</member.last-bom-update>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>io.quarkus.platform</groupId>
@@ -63,7 +66,7 @@
               <member>${project.groupId}:quarkus-blaze-persistence-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
-          <overridesFile>${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
+          <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>

--- a/generated-platform-project/quarkus-blaze-persistence/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus-blaze-persistence/descriptor/src/main/resources/overrides.json
@@ -1,0 +1,5 @@
+{
+  "metadata" : {
+    "last-bom-update" : "${member.last-bom-update}"
+  }
+}

--- a/generated-platform-project/quarkus-blaze-persistence/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/integration-tests/pom.xml
@@ -20,7 +20,7 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-universe-bom</artifactId>
-        <version>${main.bom.version}</version>
+        <version>${universal.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/generated-platform-project/quarkus-hazelcast/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-hazelcast/descriptor/pom.xml
@@ -11,6 +11,9 @@
   <artifactId>quarkus-hazelcast-client-quarkus-platform-descriptor</artifactId>
   <packaging>pom</packaging>
   <name>Quarkus Platform - Hazelcast - Quarkus Platform Descriptor</name>
+  <properties>
+    <member.last-bom-update>io.quarkus.platform:quarkus-hazelcast-client:999-SNAPSHOT</member.last-bom-update>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>io.quarkus.platform</groupId>
@@ -63,7 +66,7 @@
               <member>${project.groupId}:quarkus-blaze-persistence-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
-          <overridesFile>${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
+          <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>

--- a/generated-platform-project/quarkus-hazelcast/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus-hazelcast/descriptor/src/main/resources/overrides.json
@@ -1,0 +1,5 @@
+{
+  "metadata" : {
+    "last-bom-update" : "${member.last-bom-update}"
+  }
+}

--- a/generated-platform-project/quarkus-hazelcast/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-hazelcast/integration-tests/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-universe-bom</artifactId>
-        <version>${main.bom.version}</version>
+        <version>${universal.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
@@ -11,6 +11,9 @@
   <artifactId>quarkus-qpid-jms-bom-quarkus-platform-descriptor</artifactId>
   <packaging>pom</packaging>
   <name>Quarkus Platform - QpidJMS - Quarkus Platform Descriptor</name>
+  <properties>
+    <member.last-bom-update>io.quarkus.platform:quarkus-qpid-jms-bom:999-SNAPSHOT</member.last-bom-update>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>io.quarkus.platform</groupId>
@@ -63,7 +66,7 @@
               <member>${project.groupId}:quarkus-blaze-persistence-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
-          <overridesFile>${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
+          <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>

--- a/generated-platform-project/quarkus-qpid-jms/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus-qpid-jms/descriptor/src/main/resources/overrides.json
@@ -1,0 +1,5 @@
+{
+  "metadata" : {
+    "last-bom-update" : "${member.last-bom-update}"
+  }
+}

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-universe-bom</artifactId>
-        <version>${main.bom.version}</version>
+        <version>${universal.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/generated-platform-project/quarkus-universe/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-universe/descriptor/pom.xml
@@ -53,7 +53,7 @@
         <configuration>
           <bomArtifactId>quarkus-universe-bom</bomArtifactId>
           <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
-          <overridesFile>${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
+          <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>

--- a/generated-platform-project/quarkus-universe/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus-universe/descriptor/src/main/resources/overrides.json
@@ -10,9 +10,9 @@
         "scala-version" : "2.12.13",
         "scala-plugin-version" : "4.4.0",
         "quarkus-core-version" : "2.0.0.CR2",
-        "maven-plugin-groupId" : "${project.groupId}",
+        "maven-plugin-groupId" : "io.quarkus",
         "maven-plugin-artifactId" : "quarkus-maven-plugin",
-        "maven-plugin-version" : "${project.version}",
+        "maven-plugin-version" : "2.0.0.CR2",
         "gradle-plugin-id" : "io.quarkus",
         "gradle-plugin-version" : "2.0.0.CR2",
         "supported-maven-versions" : "[3.6.2,)",
@@ -21,8 +21,7 @@
         "gradle-wrapper-version" : "6.9"
       }
     },
-    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:2.0.0.CR2" ],
-    "last-bom-update" : "${member.last-bom-update}"
+    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:2.0.0.CR2" ]
   },
   "categories" : [ {
     "id" : "web",

--- a/generated-platform-project/quarkus/descriptor/pom.xml
+++ b/generated-platform-project/quarkus/descriptor/pom.xml
@@ -11,6 +11,9 @@
   <artifactId>quarkus-bom-quarkus-platform-descriptor</artifactId>
   <packaging>pom</packaging>
   <name>Quarkus Platform - Core - Quarkus Platform Descriptor</name>
+  <properties>
+    <member.last-bom-update>io.quarkus.platform:quarkus-bom:999-SNAPSHOT</member.last-bom-update>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>io.quarkus.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <kogito-quarkus.version>1.6.0.Final</kogito-quarkus.version>
         <optaplanner-quarkus.version>8.6.0.Final</optaplanner-quarkus.version>
 
-        <quarkus-platform-bom-generator.version>0.0.17</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.18</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <rpkgtests-maven-plugin.version>0.8.0</rpkgtests-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
@@ -77,15 +77,6 @@
         <overridesfile>
             ${resourcesdir}/extensions-overrides.json
         </overridesfile>
-
-        <!--
-           | The registry service to notify about the new platform release
-        -->
-        <!-- quarkus.registry.url>http://localhost:8080/registry/new-platform</quarkus.registry.url -->
-        <!--
-           | Whether to update the platform release config in this POM after successuflly installing the platform artifacts
-        -->
-        <!-- updatePomOnInstall>false</updatePomOnInstall -->
     </properties>
 
     <distributionManagement>
@@ -598,11 +589,11 @@
                     <plugin>
                         <artifactId>maven-release-plugin</artifactId>
                         <configuration>
-                            <!-- After the release plugin has transformed all the POMs, we need to re-generate the platform configs (mainly to re-generated POM properties)
+                            <!-- After the release plugin has transformed all the POMs, we need to re-generate the platform configs (mainly to re-generated the POM properties)
                                  taking into account the upcoming release version. Although this will happen at the `process-resources` phase anyway, this should be done
                                  using the platform invoker goal (otherwise, some dependencies relying on the generated properties may fail to resolve).
                                  Here we are deactivating the release profile to exclude the generated-platform-project module. -->
-                            <preparationGoals>clean verify -P !release</preparationGoals>
+                            <preparationGoals>clean verify -P !release -DrecordUpdatedBoms</preparationGoals>
                             <completionGoals>process-resources -P !release</completionGoals>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Fixes the universe BOM's JSON metadata by copying the missing metadata from the core.

Also introduces `lastDetectedBomUpdate` element to the member release config, the value of which is updated automatically by the tool during the release process and points to the last platform release in which the member BOM was actually updated. This value is also recorded in the member's JSON descriptor.