### PR TITLE
Update Cassandra client to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <debezium.version>1.3.0.Final</debezium.version>
         <debezium-quarkus-outbox.version>1.4.0.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.0</quarkus-blaze-persistence.version>
-        <quarkus-cassandra-client.version>1.0.1</quarkus-cassandra-client.version>
+        <quarkus-cassandra-client.version>1.0.2</quarkus-cassandra-client.version>
 
         <!-- After upgrading Kogito regenerate the test modules by running
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <debezium.version>1.3.0.Final</debezium.version>
         <debezium-quarkus-outbox.version>1.4.0.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.0</quarkus-blaze-persistence.version>
-        <quarkus-cassandra-client.version>1.0.2</quarkus-cassandra-client.version>
+        <quarkus-cassandra-client.version>1.0.3</quarkus-cassandra-client.version>
 
         <!-- After upgrading Kogito regenerate the test modules by running
 


### PR DESCRIPTION
This PR upgrades the Cassandra client for Quarkus 1.x to the latest version, published today.