### PR TITLE
Update to Quarkus Qpid JMS 0.25.0 (and Quarkus 2.0.0)

### DIFF
--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -22,10 +22,10 @@
     <module>quarkus-maven-plugin</module>
   </modules>
   <properties>
-    <platform.key>io.quarkus.platform</platform.key>
-    <platform.stream>999-SNAPSHOT</platform.stream>
-    <platform.release>0</platform.release>
     <universal.bom.version>999-SNAPSHOT</universal.bom.version>
+    <platform.release>0</platform.release>
+    <platform.stream>999-SNAPSHOT</platform.stream>
+    <platform.key>io.quarkus.platform</platform.key>
   </properties>
   <build>
     <pluginManagement>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>0.57.0</version>
+        <version>1.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -7591,12 +7591,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.24.0</version>
+        <version>0.25.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -7875,7 +7875,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>0.57.0</version>
+        <version>1.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tika</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
         <camel-quarkus.version>2.0.0-M2</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.24.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.25.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>1.2.0</quarkus-hazelcast-client.version>
         <debezium.version>1.3.0.Final</debezium.version>
         <debezium-quarkus-outbox.version>1.4.0.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.25.0, uses Qpid JMS 1.0.0 against Quarkus 2.0.0.Final

(I have based it after the latest commit b4351deafcceff3c07839ac38b6e6eb625f4cd37 from #245, updating to Quarkus 2.0.0, as it seemed a waste to bother running a build that was known to be out of date and needing to update it again. I can rebase this PR later if desired though.)