### PR TITLE
Upgrade to the BOM generator 0.0.19

### DIFF
--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -25,8 +25,8 @@
   </modules>
   <properties>
     <platform.key>io.quarkus.platform</platform.key>
+    <platform.release>999-SNAPSHOT</platform.release>
     <platform.stream>999-SNAPSHOT</platform.stream>
-    <platform.release>0</platform.release>
     <universal.bom.version>999-SNAPSHOT</universal.bom.version>
   </properties>
   <build>
@@ -35,7 +35,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-          <version>0.0.18</version>
+          <version>0.0.19</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/generated-platform-project/quarkus-universe/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-universe/descriptor/pom.xml
@@ -53,6 +53,14 @@
         <configuration>
           <bomArtifactId>quarkus-universe-bom</bomArtifactId>
           <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
+          <platformRelease>
+            <platformKey>${project.groupId}</platformKey>
+            <stream>${platform.stream}</stream>
+            <version>${platform.release}</version>
+            <members>
+              <member>${project.groupId}:quarkus-universe-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
+            </members>
+          </platformRelease>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <quarkus-google-cloud-services.version>0.8.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.18</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.19</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <rpkgtests-maven-plugin.version>0.8.0</rpkgtests-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>


### PR DESCRIPTION
* alphabetical sorting for the POM properties
* platform release metadata for the universal platform
* use the full platform version instead of the micro one to represent the platform release version