### PR TITLE
Updating Debezium to 1.6.0.Final

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -1927,6 +1927,11 @@
         <version>9.4</version>
       </dependency>
       <dependency>
+        <groupId>com.oracle.instantclient</groupId>
+        <artifactId>xstreams</artifactId>
+        <version>21.1.0.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.orbitz.consul</groupId>
         <artifactId>consul-client</artifactId>
         <version>1.3.3</version>
@@ -2005,7 +2010,7 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-api</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
@@ -2020,70 +2025,70 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mongodb</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-oracle</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-postgres</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-sqlserver</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-vitess</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ddl-parser</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/generated-platform-project/quarkus-debezium/bom/pom.xml
+++ b/generated-platform-project/quarkus-debezium/bom/pom.xml
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-deployment</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -2585,6 +2585,11 @@
         <version>21.1.0.0</version>
       </dependency>
       <dependency>
+        <groupId>com.oracle.instantclient</groupId>
+        <artifactId>xstreams</artifactId>
+        <version>21.1.0.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.orbitz.consul</groupId>
         <artifactId>consul-client</artifactId>
         <version>1.3.3</version>
@@ -2728,7 +2733,7 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-api</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
@@ -2743,80 +2748,80 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mongodb</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-oracle</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-postgres</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-sqlserver</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-vitess</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ddl-parser</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-deployment</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting</artifactId>
-        <version>1.6.0.CR1</version>
+        <version>1.6.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
         <quarkus-qpid-jms.version>0.25.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>2.0.0</quarkus-hazelcast-client.version>
-        <debezium-quarkus-outbox.version>1.6.0.CR1</debezium-quarkus-outbox.version>
+        <debezium-quarkus-outbox.version>1.6.0.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.0</quarkus-blaze-persistence.version>
         <quarkus-cassandra-client.version>1.1.0-rc2</quarkus-cassandra-client.version>
 


### PR DESCRIPTION
@gsmet @geoand, quick Debezium version update here after our 1.6 Final release last week. There were no API changes whatsoever, I suppose that update in _pom.xml_ is all that's needed? Thanks!