### PR TITLE
Exclude Debezium's provided dependency on Oracle's xstreams and enable Cassandra tests

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -1927,11 +1927,6 @@
         <version>9.4</version>
       </dependency>
       <dependency>
-        <groupId>com.oracle.instantclient</groupId>
-        <artifactId>xstreams</artifactId>
-        <version>21.1.0.0</version>
-      </dependency>
-      <dependency>
         <groupId>com.orbitz.consul</groupId>
         <artifactId>consul-client</artifactId>
         <version>1.3.3</version>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-main/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-main/pom.xml
@@ -10,9 +10,6 @@
   </parent>
   <artifactId>cassandra-quarkus-integration-tests-main</artifactId>
   <name>Quarkus Platform - Cassandra - Integration Tests - cassandra-quarkus-integration-tests-main</name>
-  <properties>
-    <maven.test.skip>true</maven.test.skip>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.datastax.oss.quarkus</groupId>
@@ -162,7 +159,6 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <skip>true</skip>
                   <appArtifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-main:${quarkus-cassandra-client.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-disabled/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-disabled/pom.xml
@@ -10,9 +10,6 @@
   </parent>
   <artifactId>cassandra-quarkus-integration-tests-metrics-disabled</artifactId>
   <name>Quarkus Platform - Cassandra - Integration Tests - cassandra-quarkus-integration-tests-metrics-disabled</name>
-  <properties>
-    <maven.test.skip>true</maven.test.skip>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.datastax.oss.quarkus</groupId>
@@ -162,7 +159,6 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <skip>true</skip>
                   <appArtifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-metrics-disabled:${quarkus-cassandra-client.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-microprofile/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-microprofile/pom.xml
@@ -10,9 +10,6 @@
   </parent>
   <artifactId>cassandra-quarkus-integration-tests-metrics-microprofile</artifactId>
   <name>Quarkus Platform - Cassandra - Integration Tests - cassandra-quarkus-integration-tests-metrics-microprofile</name>
-  <properties>
-    <maven.test.skip>true</maven.test.skip>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.datastax.oss.quarkus</groupId>
@@ -162,7 +159,6 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <skip>true</skip>
                   <appArtifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-metrics-microprofile:${quarkus-cassandra-client.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-no-mapper/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-no-mapper/pom.xml
@@ -10,9 +10,6 @@
   </parent>
   <artifactId>cassandra-quarkus-integration-tests-no-mapper</artifactId>
   <name>Quarkus Platform - Cassandra - Integration Tests - cassandra-quarkus-integration-tests-no-mapper</name>
-  <properties>
-    <maven.test.skip>true</maven.test.skip>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.datastax.oss.quarkus</groupId>
@@ -162,7 +159,6 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <skip>true</skip>
                   <appArtifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-no-mapper:${quarkus-cassandra-client.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -2585,11 +2585,6 @@
         <version>21.1.0.0</version>
       </dependency>
       <dependency>
-        <groupId>com.oracle.instantclient</groupId>
-        <artifactId>xstreams</artifactId>
-        <version>21.1.0.0</version>
-      </dependency>
-      <dependency>
         <groupId>com.orbitz.consul</groupId>
         <artifactId>consul-client</artifactId>
         <version>1.3.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -253,32 +253,23 @@
                                     <next>${project.groupId}:quarkus-cassandra-bom:${project.version}</next>
                                 </release>
                                 <defaultTestConfig>
-                                    <skip>true</skip>
+                                    <skip>false</skip>
+                                    <mavenFailsafePlugin>true</mavenFailsafePlugin>
+                                    <groups>!native</groups>
+                                    <nativeGroups>native</nativeGroups>
                                 </defaultTestConfig>
                                 <tests>
                                     <test>
                                         <artifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-main:${quarkus-cassandra-client.version}</artifact>
-                                        <mavenFailsafePlugin>true</mavenFailsafePlugin>
-                                        <groups>!native</groups>
-                                        <nativeGroups>native</nativeGroups>
                                     </test>
                                     <test>
                                         <artifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-metrics-disabled:${quarkus-cassandra-client.version}</artifact>
-                                        <mavenFailsafePlugin>true</mavenFailsafePlugin>
-                                        <groups>!native</groups>
-                                        <nativeGroups>native</nativeGroups>
                                     </test>
                                     <test>
                                         <artifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-metrics-microprofile:${quarkus-cassandra-client.version}</artifact>
-                                        <mavenFailsafePlugin>true</mavenFailsafePlugin>
-                                        <groups>!native</groups>
-                                        <nativeGroups>native</nativeGroups>
                                     </test>
                                     <test>
                                         <artifact>com.datastax.oss.quarkus:cassandra-quarkus-integration-tests-no-mapper:${quarkus-cassandra-client.version}</artifact>
-                                        <mavenFailsafePlugin>true</mavenFailsafePlugin>
-                                        <groups>!native</groups>
-                                        <nativeGroups>native</nativeGroups>
                                     </test>
                                 </tests>
                             </member>
@@ -408,6 +399,7 @@
                             <excludedDependencies>
                                 <dependency>io.quarkus:quarkus-bom-quarkus-platform-descriptor:${quarkus.version}:json</dependency>
                                 <dependency>io.quarkus:quarkus-bom-quarkus-platform-properties::properties</dependency>
+                                <dependency>com.oracle.instantclient:xstreams</dependency> <!-- provided dependency of a Debezium extension, supposed to be added by users manually -->
                             </excludedDependencies>
                         </bomGenerator>
                         <descriptorGenerator>


### PR DESCRIPTION
* Exclude Debezium's provided dependency on Oracle's xstreams;
* Enable Cassandra tests

Just FYI, @gunnarmorling and @Naros, the xstreams dependency gets added in your local builds because, I guess, it is present in your local repo and/or is resolvable in your environment. But it's not resolvable in my environment and so it gets filtered out.
Interestingly, it's not even brought in by your config because you don't even have a BOM. It's the Camel BOM that is the origin of it.
Anyway, I am excluding it from the BOM for now. The best approach here would be to run the build in a github action as part of the CI and commit the changes from it, instead of relying on the maintainer's build env.