### PR TITLE
Update to Quarkus Qpid JMS 0.26.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -7963,7 +7963,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tinkerpop</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.25.0</version>
+        <version>0.26.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.25.0</version>
+        <version>0.26.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -8705,12 +8705,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.25.0</version>
+        <version>0.26.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.25.0</version>
+        <version>0.26.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -14716,7 +14716,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tika</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
         <camel-quarkus.version>2.0.0</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.25.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.26.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>2.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.6.0.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.1</quarkus-blaze-persistence.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.26.0, uses Qpid JMS 1.1.0 against Quarkus 2.1.0.Final