### PR TITLE
Disable camel-quarkus-integration-test-js-dsl for now

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-js-dsl</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-js-dsl</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -159,6 +162,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -13,6 +13,7 @@
   <name>Quarkus Platform - Camel - Integration Tests - Parent</name>
   <modules>
     <module>camel-quarkus-integration-test-avro-rpc</module>
+    <module>camel-quarkus-integration-test-js-dsl</module>
     <module>camel-quarkus-integration-test-activemq</module>
     <module>camel-quarkus-integration-test-amqp</module>
     <module>camel-quarkus-integration-test-arangodb</module>
@@ -79,7 +80,6 @@
     <module>camel-quarkus-integration-test-jira</module>
     <module>camel-quarkus-integration-test-jolt</module>
     <module>camel-quarkus-integration-test-jpa</module>
-    <module>camel-quarkus-integration-test-js-dsl</module>
     <module>camel-quarkus-integration-test-jsch</module>
     <module>camel-quarkus-integration-test-jslt</module>
     <module>camel-quarkus-integration-test-json-validator</module>

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,10 @@
                                         <skip>true</skip>
                                         <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-avro-rpc:${camel-quarkus.version}</artifact>
                                     </test>
+                                    <test>
+                                        <skip>true</skip>
+                                        <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl:${camel-quarkus.version}</artifact>
+                                    </test>
                                 </tests>
                             </member>
                             <member>


### PR DESCRIPTION
Triggers java.lang.ClassNotFoundException: org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineImpl