### PR TITLE
Disable camel-quarkus-integration-test-xchange for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,10 @@
                                         <skip>true</skip>
                                         <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl:${camel-quarkus.version}</artifact>
                                     </test>
+                                    <test>
+                                        <skip>true</skip>
+                                        <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xchange:${camel-quarkus.version}</artifact>
+                                    </test>
                                 </tests>
                             </member>
                             <member>


### PR DESCRIPTION
Due to:
```
2021-08-18T14:01:41.2962242Z 2021-08-18 14:01:41,290 WARN  [si.maz.res.ResponseReader] (executor-thread-0) Noncritical error parsing error output: This endpoint has been deprecated, please integrate with “GET@/sapi/v1/asset/assetDetail”. See details in the announcement: https://www.binance.com/en/support/announcement/f45dde7da58b473aa885349946be...: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'This': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
2021-08-18T14:01:41.2967285Z  at [Source: (String)"This endpoint has been deprecated, please integrate with “GET@/sapi/v1/asset/assetDetail”. See details in the announcement: https://www.binance.com/en/support/announcement/f45dde7da58b473aa885349946bed269"; line: 1, column: 5]
2021-08-18T14:01:41.2974368Z 	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2337)
2021-08-18T14:01:41.2982428Z 	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:720)
2021-08-18T14:01:41.2991430Z 	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._reportInvalidToken(ReaderBasedJsonParser.java:2903)
2021-08-18T14:01:41.3000593Z 	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._handleOddValue(ReaderBasedJsonParser.java:1949)
2021-08-18T14:01:41.3010412Z 	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:781)
2021-08-18T14:01:41.3039398Z 	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4684)
2021-08-18T14:01:41.3042533Z 	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4586)
2021-08-18T14:01:41.3045580Z 	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3548)
2021-08-18T14:01:41.3049001Z 	at si.mazi.rescu.serialization.jackson.JacksonResponseReader.read(JacksonResponseReader.java:53)
```

/cc @ppalaga 