### PR TITLE
Temporarily disable camel-google-pubsub tests

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -5,5 +5,4 @@ set -e
 mvn versions:set-property -pl . -Dproperty=quarkus.version -DnewVersion=999-SNAPSHOT
 
 # just run all the tests
-# TODO: Reinstate camel https://github.com/apache/camel-quarkus/issues/2621
 mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B -ntp clean install

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-google-pubsub</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-google-pubsub</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -159,6 +162,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-pubsub:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -13,6 +13,7 @@
   <name>Quarkus Platform - Camel - Integration Tests - Parent</name>
   <modules>
     <module>camel-quarkus-integration-test-avro-rpc</module>
+    <module>camel-quarkus-integration-test-google-pubsub</module>
     <module>camel-quarkus-integration-test-js-dsl</module>
     <module>camel-quarkus-integration-test-xchange</module>
     <module>camel-quarkus-integration-test-activemq</module>
@@ -59,7 +60,6 @@
     <module>camel-quarkus-integration-test-git</module>
     <module>camel-quarkus-integration-test-github</module>
     <module>camel-quarkus-integration-test-google-bigquery</module>
-    <module>camel-quarkus-integration-test-google-pubsub</module>
     <module>camel-quarkus-integration-test-google-storage</module>
     <module>camel-quarkus-integration-test-google</module>
     <module>camel-quarkus-integration-test-graphql</module>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,10 @@
                                     </test>
                                     <test>
                                         <skip>true</skip>
+                                        <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-pubsub:${camel-quarkus.version}</artifact>
+                                    </test>
+                                    <test>
+                                        <skip>true</skip>
                                         <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl:${camel-quarkus.version}</artifact>
                                     </test>
                                     <test>


### PR DESCRIPTION
Relates to latest quarkus-platform nightly build failure https://github.com/apache/camel-quarkus/issues/3027.