### PR TITLE
Upgrade to the platform generator 0.0.28

### DIFF
--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -36,7 +36,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-          <version>0.0.27</version>
+          <version>0.0.28</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <quarkus-google-cloud-services.version>0.10.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.27</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.28</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <rpkgtests-maven-plugin.version>0.8.0</rpkgtests-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>


### PR DESCRIPTION
Contains a fix for verifying the existence of the settings files before actually enabling them when invoking the generated-platform-project.