### PR TITLE
Disable failing OptaPlanner test

### DIFF
--- a/generated-platform-project/quarkus-optaplanner/integration-tests/optaplanner-quarkus-devui-integration-test/pom.xml
+++ b/generated-platform-project/quarkus-optaplanner/integration-tests/optaplanner-quarkus-devui-integration-test/pom.xml
@@ -10,6 +10,9 @@
   </parent>
   <artifactId>optaplanner-quarkus-devui-integration-test</artifactId>
   <name>Quarkus Platform - OptaPlanner - Integration Tests - optaplanner-quarkus-devui-integration-test</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.optaplanner</groupId>
@@ -134,6 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.optaplanner:optaplanner-quarkus-devui-integration-test:${optaplanner-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,8 @@
                                         <artifact>org.optaplanner:optaplanner-quarkus-drl-integration-test:${optaplanner-quarkus.version}</artifact>
                                     </test>
                                     <test>
+                                        <!-- TODO: remove the skip with upgrade to OptaPlanner 8.12.0.Final. -->
+                                        <skip>true</skip>
                                         <artifact>org.optaplanner:optaplanner-quarkus-devui-integration-test:${optaplanner-quarkus.version}</artifact>
                                     </test>
                                     <test>


### PR DESCRIPTION
Disabling a failing test until the fix gets into the platform (see https://github.com/quarkusio/quarkus/issues/8593).