### PR TITLE
Camel config - use predefined resourcesdir property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
                                         <!-- https://github.com/quarkusio/quarkus/issues/20228  -->
                                         <quarkus.https.test-port>$${test.https.port.native}</quarkus.https.test-port>
                                     </nativeSystemProperties>
-                                    <transformWith>src/main/resources/xslt/camel/test-pom.xsl</transformWith>
+                                    <transformWith>${resourcesdir}/xslt/camel/test-pom.xsl</transformWith>
                                 </defaultTestConfig>
                                 <testCatalogArtifact>org.apache.camel.quarkus:camel-quarkus-test-list::xml:${camel-quarkus.version}</testCatalogArtifact>
                                 <tests>


### PR DESCRIPTION
Reusing existing `${resourcesdir}` property for Camel member config.

Issue with the original setting was that it was not able to run build from another directory, using `mvn -f path/to/quarkus-platform`.

@aloubyansky @ppalaga if you could take a look.