### PR TITLE
Disable Camel Spring RabbitMQ tests

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-spring-rabbitmq</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-spring-rabbitmq</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -170,6 +173,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-spring-rabbitmq:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -21,6 +21,7 @@
     <module>camel-quarkus-integration-test-kafka-ssl</module>
     <module>camel-quarkus-integration-test-rabbitmq</module>
     <module>camel-quarkus-integration-test-salesforce</module>
+    <module>camel-quarkus-integration-test-spring-rabbitmq</module>
     <module>camel-quarkus-integration-test-activemq</module>
     <module>camel-quarkus-integration-test-amqp</module>
     <module>camel-quarkus-integration-test-arangodb</module>
@@ -160,7 +161,6 @@
     <module>camel-quarkus-integration-test-soap</module>
     <module>camel-quarkus-integration-test-solr</module>
     <module>camel-quarkus-integration-test-splunk</module>
-    <module>camel-quarkus-integration-test-spring-rabbitmq</module>
     <module>camel-quarkus-integration-test-sql</module>
     <module>camel-quarkus-ssh-integration-test</module>
     <module>camel-quarkus-integration-test-stax</module>

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,10 @@
                                         <skip>true</skip>
                                         <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-salesforce:${camel-quarkus.version}</artifact>
                                     </test>
+                                    <test><!-- Workaround for Spring RabbitMQ tests failing with Quarkus 999-SNAPSHOT and CQ 2.4.0  -->
+                                        <skip>true</skip>
+                                        <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-spring-rabbitmq:${camel-quarkus.version}</artifact>
+                                    </test>
                                 </tests>
                             </member>
                             <member>


### PR DESCRIPTION
As I mentioned [here](https://github.com/quarkusio/quarkus/issues/8593#issuecomment-956009053), I think in the long term it'll be better to start testing with CQ SNAPSHOTS so that we don't have to constantly enable / disable tests.
