### PR TITLE
Platform generator 0.0.36

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,4 +92,4 @@ jobs:
         if: ${{ steps.get-changes.outputs.changes > 0 }}
         with:
           script: |
-            throw new Error('Generated project needs an update. Please run ./mvnw clean process-resources and include the result in your pull request.')
+            throw new Error('Generated project needs an update. Please run ./mvnw -Dsync and include the result in your pull request.')

--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -36,7 +36,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-          <version>0.0.35</version>
+          <version>0.0.36</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -36,7 +36,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-          <version>0.0.34</version>
+          <version>0.0.35</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -289,6 +289,26 @@
         <version>3.11.0</version>
       </dependency>
       <dependency>
+        <groupId>com.datastax.oss.quarkus</groupId>
+        <artifactId>cassandra-quarkus-client-deployment</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss.quarkus</groupId>
+        <artifactId>cassandra-quarkus-client</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss.quarkus</groupId>
+        <artifactId>cassandra-quarkus-mapper-processor</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss.quarkus</groupId>
+        <artifactId>cassandra-quarkus-test-framework</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-core-shaded</artifactId>
         <version>4.13.0</version>
@@ -399,6 +419,26 @@
         <groupId>com.google.zxing</groupId>
         <artifactId>core</artifactId>
         <version>3.3.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast</artifactId>
+        <version>4.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>quarkus-hazelcast-client-deployment</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>quarkus-hazelcast-client</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>quarkus-test-hazelcast</artifactId>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
@@ -517,6 +557,89 @@
         <version>6.0.2</version>
       </dependency>
       <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-api</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-cassandra</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-db2</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-mongodb</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-mysql</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-mysql</artifactId>
+        <version>1.6.1.Final</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-oracle</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-postgres</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-sqlserver</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-vitess</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-core</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-core</artifactId>
+        <version>1.6.1.Final</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-ddl-parser</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-embedded</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-embedded</artifactId>
+        <version>1.6.1.Final</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-scripting</artifactId>
+        <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
         <version>4.1.19</version>
@@ -602,19 +725,9 @@
         <version>3.4.5</version>
       </dependency>
       <dependency>
-        <groupId>io.reactivex</groupId>
-        <artifactId>rxjava</artifactId>
-        <version>1.3.8</version>
-      </dependency>
-      <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-reactive-messaging-camel</artifactId>
         <version>3.11.0</version>
-      </dependency>
-      <dependency>
-        <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-graphql-client-implementation-jaxrs</artifactId>
-        <version>1.2.5</version>
       </dependency>
       <dependency>
         <groupId>io.vitess</groupId>
@@ -632,11 +745,6 @@
         <version>1.1.1</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.1</version>
-      </dependency>
-      <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
         <version>1.2.0</version>
@@ -645,11 +753,6 @@
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>2.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -672,29 +775,19 @@
         <version>5.8.0</version>
       </dependency>
       <dependency>
-        <groupId>net.minidev</groupId>
-        <artifactId>json-smart</artifactId>
-        <version>2.4.7</version>
-      </dependency>
-      <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>affinity</artifactId>
         <version>3.20.0</version>
       </dependency>
       <dependency>
-        <groupId>net.sourceforge.htmlunit</groupId>
-        <artifactId>htmlunit</artifactId>
-        <version>2.40.0</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>httpmime</artifactId>
-            <groupId>org.apache.httpcomponents</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>commons-logging</artifactId>
-            <groupId>commons-logging</groupId>
-          </exclusion>
-        </exclusions>
+        <groupId>org.amqphub.quarkus</groupId>
+        <artifactId>quarkus-qpid-jms-deployment</artifactId>
+        <version>0.29.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.amqphub.quarkus</groupId>
+        <artifactId>quarkus-qpid-jms</artifactId>
+        <version>0.29.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -6401,21 +6494,6 @@
         <version>1.14.0</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.maven.resolver</groupId>
-        <artifactId>maven-resolver-transport-file</artifactId>
-        <version>1.6.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.resolver</groupId>
-        <artifactId>maven-resolver-transport-http</artifactId>
-        <version>1.6.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-artifact</artifactId>
-        <version>3.8.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
         <version>1.3.0</version>
@@ -7016,11 +7094,6 @@
         <version>1.5.31</version>
       </dependency>
       <dependency>
-        <groupId>org.jprocesses</groupId>
-        <artifactId>jProcesses</artifactId>
-        <version>1.6.5</version>
-      </dependency>
-      <dependency>
         <groupId>org.jruby.jcodings</groupId>
         <artifactId>jcodings</artifactId>
         <version>1.0.55</version>
@@ -7060,6 +7133,26 @@
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-generator-annprocess</artifactId>
         <version>1.21</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-deployment</artifactId>
+        <version>8.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-jackson-deployment</artifactId>
+        <version>8.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus-jackson</artifactId>
+        <version>8.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-quarkus</artifactId>
+        <version>8.13.0.Final</version>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>
@@ -7119,11 +7212,6 @@
         <version>5.3.10</version>
       </dependency>
       <dependency>
-        <groupId>org.subethamail</groupId>
-        <artifactId>subethasmtp</artifactId>
-        <version>3.1.7</version>
-      </dependency>
-      <dependency>
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
         <version>1.5.1</version>
@@ -7147,11 +7235,6 @@
         <groupId>org.web3j</groupId>
         <artifactId>quorum</artifactId>
         <version>0.8.0</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>aws-ion-protocol</artifactId>
-        <version>2.16.81</version>
       </dependency>
       <dependency>
         <groupId>xalan</groupId>

--- a/generated-platform-project/quarkus-camel/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-camel/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>org.apache.camel.quarkus</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>com.datastax.oss.quarkus</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/generated-platform-project/quarkus-hazelcast/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-hazelcast/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>com.hazelcast</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/generated-platform-project/quarkus-kogito/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-kogito/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>org.kie.kogito</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/generated-platform-project/quarkus-optaplanner/bom/pom.xml
+++ b/generated-platform-project/quarkus-optaplanner/bom/pom.xml
@@ -150,6 +150,46 @@
         <version>1.5.3</version>
       </dependency>
       <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-compiler</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-core-dynamic</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-core</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-drools-model</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-legacy-api</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-rules-deployment</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-rules</artifactId>
+        <version>1.13.0.Final</version>
+      </dependency>
+      <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kie-api</artifactId>
         <version>8.13.0.Beta</version>

--- a/generated-platform-project/quarkus-optaplanner/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-optaplanner/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>org.optaplanner</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>org.amqphub.quarkus</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -3340,6 +3340,12 @@
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-mysql</artifactId>
+        <version>1.6.1.Final</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-oracle</artifactId>
         <version>1.6.1.Final</version>
       </dependency>
@@ -3365,6 +3371,12 @@
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
+        <artifactId>debezium-core</artifactId>
+        <version>1.6.1.Final</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
         <artifactId>debezium-ddl-parser</artifactId>
         <version>1.6.1.Final</version>
       </dependency>
@@ -3372,6 +3384,12 @@
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
         <version>1.6.1.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-embedded</artifactId>
+        <version>1.6.1.Final</version>
+        <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
@@ -7614,11 +7632,6 @@
         <version>2.2.21</version>
       </dependency>
       <dependency>
-        <groupId>io.reactivex</groupId>
-        <artifactId>rxjava</artifactId>
-        <version>1.3.8</version>
-      </dependency>
-      <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>json-schema-validator</artifactId>
         <version>4.4.0</version>
@@ -8343,11 +8356,6 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-graphql-client-api</artifactId>
         <version>1.3.5</version>
-      </dependency>
-      <dependency>
-        <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-graphql-client-implementation-jaxrs</artifactId>
-        <version>1.2.5</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
@@ -9401,11 +9409,6 @@
         <version>1.1.1</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.1</version>
-      </dependency>
-      <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
         <version>1.2.0</version>
@@ -9414,11 +9417,6 @@
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>2.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -9457,29 +9455,9 @@
         <version>5.8.0</version>
       </dependency>
       <dependency>
-        <groupId>net.minidev</groupId>
-        <artifactId>json-smart</artifactId>
-        <version>2.4.7</version>
-      </dependency>
-      <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>affinity</artifactId>
         <version>3.20.0</version>
-      </dependency>
-      <dependency>
-        <groupId>net.sourceforge.htmlunit</groupId>
-        <artifactId>htmlunit</artifactId>
-        <version>2.40.0</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>httpmime</artifactId>
-            <groupId>org.apache.httpcomponents</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>commons-logging</artifactId>
-            <groupId>commons-logging</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.aesh</groupId>
@@ -15394,16 +15372,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
-        <artifactId>maven-resolver-transport-file</artifactId>
-        <version>1.6.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.resolver</groupId>
-        <artifactId>maven-resolver-transport-http</artifactId>
-        <version>1.6.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-transport-wagon</artifactId>
         <version>1.6.2</version>
         <exclusions>
@@ -15484,11 +15452,6 @@
             <groupId>commons-io</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-artifact</artifactId>
-        <version>3.8.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -17204,11 +17167,6 @@
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>1.5.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jprocesses</groupId>
-        <artifactId>jProcesses</artifactId>
-        <version>1.6.5</version>
       </dependency>
       <dependency>
         <groupId>org.jruby.jcodings</groupId>
@@ -20336,11 +20294,6 @@
         <version>5.3.10</version>
       </dependency>
       <dependency>
-        <groupId>org.subethamail</groupId>
-        <artifactId>subethasmtp</artifactId>
-        <version>3.1.7</version>
-      </dependency>
-      <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>azure</artifactId>
         <version>1.16.2</version>
@@ -20840,11 +20793,6 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>aws-core</artifactId>
         <version>2.17.78</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>aws-ion-protocol</artifactId>
-        <version>2.16.81</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/generated-platform-project/quarkus/descriptor/pom.xml
+++ b/generated-platform-project/quarkus/descriptor/pom.xml
@@ -72,6 +72,9 @@
               <member>${project.groupId}:quarkus-google-cloud-services-bom-quarkus-platform-descriptor:${project.version}:json:${project.version}</member>
             </members>
           </platformRelease>
+          <processGroupIds>
+            <groupId>io.quarkus</groupId>
+          </processGroupIds>
           <overridesFile>${project.basedir}/target/classes/overrides.json,${project.basedir}/../../../src/main/resources/extensions-overrides.json</overridesFile>
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <quarkus-google-cloud-services.version>0.10.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.35</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.36</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <rpkgtests-maven-plugin.version>0.8.0</rpkgtests-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -658,6 +658,24 @@
                 </plugins>
             </build>
         </profile>
+
+        <!--
+           | A convenience profile to re-generate the generated-platform-project before opening a PR
+        -->
+        <profile>
+            <id>sync</id>
+            <activation>
+                <property>
+                    <name>sync</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.invoke-platform-project.skip>true</quarkus.invoke-platform-project.skip>
+            </properties>
+            <build>
+                <defaultGoal>clean process-resources</defaultGoal>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <quarkus-google-cloud-services.version>0.10.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.34</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.35</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <rpkgtests-maven-plugin.version>0.8.0</rpkgtests-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
@@ -498,6 +498,10 @@
                             <originalPluginCoords>io.quarkus:quarkus-maven-plugin:${quarkus.version}</originalPluginCoords>
                             <targetPluginCoords>${platform.groupId}:quarkus-maven-plugin:${platform.version}</targetPluginCoords>
                         </attachedMavenPlugin>
+
+                        <!-- Uncomment to create a ZIP with the BOM reports
+                        <generateBomReportsZip>${project.build.directory}/reports.zip</generateBomReportsZip>
+                        -->
                     </platformConfig>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This upgrade includes a few changes:
* it drops filtering of what appears to be constraints managed by other members from a member BOM;
* it detects all the platform BOM imports in the original member BOMs and subtracts all of them instead of only detected `io.quarkus:quarkus-bom` imports;
* introduces an option to disabled BOM report generation and an option to create a ZIP containing the reports.

This PR also includes a commit adding `sync` Maven profile that is a convenience to quickly sync the `generated-platform-project` with the platform config in the root `pom.xml`. So, instead of `mvn clean process-resources` previously, `mvn -Dsync` can be used before pushing changes and opening a PR.