### PR TITLE
Upgrade to the platform generator 0.0.37

### DIFF
--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -36,7 +36,7 @@
         <plugin>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
-          <version>0.0.36</version>
+          <version>${quarkus-platform-bom-generator.version}</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -121,12 +121,12 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-communication-common</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-communication-identity</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.0</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
@@ -236,17 +236,17 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-security-keyvault-keys</artifactId>
-        <version>4.3.0</version>
+        <version>4.2.8</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-security-keyvault-secrets</artifactId>
-        <version>4.3.0</version>
+        <version>4.2.8</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-storage-blob-batch</artifactId>
-        <version>12.11.1</version>
+        <version>12.9.1</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
@@ -271,7 +271,7 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-storage-file-share</artifactId>
-        <version>12.11.1</version>
+        <version>12.9.1</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
@@ -281,7 +281,7 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-storage-queue</artifactId>
-        <version>12.11.1</version>
+        <version>12.9.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.cassandra</groupId>
@@ -647,17 +647,17 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-healthchecks</artifactId>
-        <version>4.1.19</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jmx</artifactId>
-        <version>4.1.19</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-servlets</artifactId>
-        <version>4.1.19</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>io.projectreactor.addons</groupId>
@@ -6445,7 +6445,7 @@
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>4.3.0</version>
+        <version>4.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
@@ -7061,7 +7061,7 @@
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js-scriptengine</artifactId>
-        <version>21.2.0</version>
+        <version>20.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.graalvm.js</groupId>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
@@ -8,9 +8,6 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-azure-grouped</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-azure-grouped</name>
-  <properties>
-    <maven.test.skip>true</maven.test.skip>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -174,7 +171,6 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-azure-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -13,7 +13,6 @@
   <name>Quarkus Platform - Camel - Integration Tests - Parent</name>
   <modules>
     <module>camel-quarkus-integration-test-main-unknown-args-ignore</module>
-    <module>camel-quarkus-integration-test-azure-grouped</module>
     <module>camel-quarkus-integration-test-fop</module>
     <module>camel-quarkus-integration-test-geocoder</module>
     <module>camel-quarkus-integration-test-js-dsl</module>
@@ -33,6 +32,7 @@
     <module>camel-quarkus-integration-test-aws2-grouped</module>
     <module>camel-quarkus-integration-test-aws2-quarkus-client-grouped</module>
     <module>camel-quarkus-integration-test-aws2</module>
+    <module>camel-quarkus-integration-test-azure-grouped</module>
     <module>camel-quarkus-integration-test-base64</module>
     <module>camel-quarkus-integration-test-bean-validator</module>
     <module>camel-quarkus-integration-test-bindy</module>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -218,12 +218,12 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-communication-common</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-communication-identity</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.0</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
@@ -333,17 +333,17 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-security-keyvault-keys</artifactId>
-        <version>4.3.0</version>
+        <version>4.2.8</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-security-keyvault-secrets</artifactId>
-        <version>4.3.0</version>
+        <version>4.2.8</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-storage-blob-batch</artifactId>
-        <version>12.11.1</version>
+        <version>12.9.1</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
@@ -368,7 +368,7 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-storage-file-share</artifactId>
-        <version>12.11.1</version>
+        <version>12.9.1</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>
@@ -378,7 +378,7 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-storage-queue</artifactId>
-        <version>12.11.1</version>
+        <version>12.9.1</version>
       </dependency>
       <dependency>
         <groupId>com.blazebit</groupId>
@@ -3438,17 +3438,17 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-healthchecks</artifactId>
-        <version>4.1.19</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jmx</artifactId>
-        <version>4.1.19</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-servlets</artifactId>
-        <version>4.1.19</version>
+        <version>4.0.1</version>
       </dependency>
       <dependency>
         <groupId>io.fabric8.kubernetes</groupId>
@@ -15224,7 +15224,7 @@
       <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>4.3.0</version>
+        <version>4.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.curator</groupId>
@@ -16459,7 +16459,7 @@
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js-scriptengine</artifactId>
-        <version>21.2.0</version>
+        <version>20.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.graalvm.js</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,8 @@
 
         <quarkus-google-cloud-services.version>0.10.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.36</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.37</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
-        <rpkgtests-maven-plugin.version>0.8.0</rpkgtests-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>
@@ -323,10 +322,6 @@
                                     <test><!-- Workaround for https://github.com/apache/camel-quarkus/pull/3055 -->
                                         <skip>true</skip>
                                         <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-unknown-args-ignore:${camel-quarkus.version}</artifact>
-                                    </test>
-                                    <test><!-- Workaround for azure-grouped tests failing with Quarkus 999-SNAPSHOT and CQ 2.3.0  -->
-                                        <skip>true</skip>
-                                        <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-azure-grouped:${camel-quarkus.version}</artifact>
                                     </test>
                                     <test><!-- Workaround for fop tests failing with Quarkus 999-SNAPSHOT and CQ 2.4.0  -->
                                         <skip>true</skip>


### PR DESCRIPTION
This release disables the alignment of member own constraints if no other member includes constraints that create a conflict. (This also reduces the platform generation time). The previous behavior can be enabled by adding `<alignOwnConstraints>true</alignOwnConstraints>` element to a member's config.

For example, Camel Quarkus imports the Azure SDK BOM and no other member includes these constraints. This release will not attempt to align them by default.

FYI @ppalaga @jamesnetherton @vkasala