### PR TITLE
Update to Quarkus Qpid JMS 0.30.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -782,12 +782,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.29.0</version>
+        <version>0.30.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.29.0</version>
+        <version>0.30.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.29.0</version>
+        <version>0.30.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.29.0</version>
+        <version>0.30.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -9511,12 +9511,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.29.0</version>
+        <version>0.30.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.29.0</version>
+        <version>0.30.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
         <camel-quarkus.version>2.4.0</camel-quarkus.version>
 
-        <quarkus-qpid-jms.version>0.29.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.30.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>2.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.6.1.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.3</quarkus-blaze-persistence.version>


### PR DESCRIPTION
 Update to Quarkus Qpid JMS 0.30.0, uses Qpid JMS 1.3.0 against Quarkus 2.5.0.Final.