### PR TITLE
Upgrade to the platform generator 0.0.39 to re-build the platform Maven plugin from sources

### DIFF
--- a/generated-platform-project/quarkus-maven-plugin/pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/pom.xml
@@ -22,39 +22,202 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-bootstrap-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core-deployment</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>quarkus-ide-launcher</artifactId>
+          <groupId>io.quarkus</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-project-core-extension-codestarts</artifactId>
+      <version>${quarkus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-devtools-common</artifactId>
+      <version>${quarkus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>javax.inject</artifactId>
+          <groupId>javax.inject</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>cdi-api</artifactId>
+          <groupId>javax.enterprise</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>plexus-classworlds</artifactId>
+          <groupId>org.codehaus.plexus</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>javax.inject</artifactId>
+          <groupId>javax.inject</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>checker-qual</artifactId>
+          <groupId>org.checkerframework</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jsr305</artifactId>
+          <groupId>com.google.code.findbugs</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-artifact-transfer</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>plexus-classworlds</artifactId>
+          <groupId>org.codehaus.plexus</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>commons-codec</artifactId>
+          <groupId>commons-codec</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>maven-shared-utils</artifactId>
+          <groupId>org.apache.maven.shared</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>maven-model</artifactId>
+          <groupId>org.apache.maven</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>maven-artifact</artifactId>
+          <groupId>org.apache.maven</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+      <version>2.3.31</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.twdata.maven</groupId>
+      <artifactId>mojo-executor</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.slf4j</groupId>
+      <artifactId>slf4j-jboss-logmanager</artifactId>
+    </dependency>
+  </dependencies>
   <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>create-extension-templates/**/*</exclude>
+        </excludes>
+      </resource>
+      <resource>
+        <filtering>false</filtering>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>create-extension-templates/**/*</include>
+        </includes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-resources</phase>
+            <phase>package</phase>
             <goals>
-              <goal>attach-maven-plugin</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <originalPluginCoords>io.quarkus:quarkus-maven-plugin:2.5.0.Final</originalPluginCoords>
-              <targetPluginCoords>io.quarkus.platform:quarkus-maven-plugin:999-SNAPSHOT</targetPluginCoords>
+              <artifactSet>
+                <includes>
+                  <include>org.fusesource.jansi:jansi</include>
+                </includes>
+              </artifactSet>
             </configuration>
           </execution>
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.coderplus.maven.plugins</groupId>
-        <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0</version>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-metadata</artifactId>
+        <version>2.1.0</version>
         <executions>
           <execution>
-            <id>copy-plugin-help</id>
-            <phase>process-classes</phase>
             <goals>
-              <goal>copy</goal>
+              <goal>generate-metadata</goal>
             </goals>
-            <configuration>
-              <sourceFile>${project.build.outputDirectory}/META-INF/maven/io.quarkus.platform/quarkus-maven-plugin/plugin-help.xml</sourceFile>
-              <destinationFile>${project.build.outputDirectory}/META-INF/maven/io.quarkus/quarkus-maven-plugin/plugin-help.xml</destinationFile>
-            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <staticMetadataDirectory>${basedir}/target/filtered-resources/META-INF/plexus</staticMetadataDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <goalPrefix>quarkus</goalPrefix>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/AddExtensionMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/AddExtensionMojo.java
@@ -1,0 +1,71 @@
+package io.quarkus.maven;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.devtools.commands.AddExtensions;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+
+/**
+ * Allow adding an extension to an existing pom.xml file.
+ * Because you can add one or several extension in one go, there are 2 mojos:
+ * {@code add-extensions} and {@code add-extension}. Both supports the {@code extension} and {@code extensions}
+ * parameters.
+ */
+@Mojo(name = "add-extension")
+public class AddExtensionMojo extends QuarkusProjectMojoBase {
+
+    /**
+     * The list of extensions to be added.
+     */
+    @Parameter(property = "extensions")
+    Set<String> extensions;
+
+    /**
+     * For usability reason, this parameter allow adding a single extension.
+     */
+    @Parameter(property = "extension")
+    String extension;
+
+    @Override
+    protected void validateParameters() throws MojoExecutionException {
+        if ((StringUtils.isBlank(extension) && (extensions == null || extensions.isEmpty())) // None are set
+                || (!StringUtils.isBlank(extension) && extensions != null && !extensions.isEmpty())) { // Both are set
+            throw new MojoExecutionException("Either the `extension` or `extensions` parameter must be set");
+        }
+    }
+
+    @Override
+    public void doExecute(final QuarkusProject quarkusProject, final MessageWriter log)
+            throws MojoExecutionException {
+        Set<String> ext = new HashSet<>();
+        if (extensions != null && !extensions.isEmpty()) {
+            ext.addAll(extensions);
+        } else {
+            // Parse the "extension" just in case it contains several comma-separated values
+            // https://github.com/quarkusio/quarkus/issues/2393
+            ext.addAll(Arrays.stream(extension.split(",")).map(String::trim).collect(toSet()));
+        }
+
+        try {
+            AddExtensions addExtensions = new AddExtensions(quarkusProject)
+                    .extensions(ext.stream().map(String::trim).collect(toSet()));
+            final QuarkusCommandOutcome outcome = addExtensions.execute();
+            if (!outcome.isSuccess()) {
+                throw new MojoExecutionException("Unable to add extensions");
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("Unable to update the pom.xml file", e);
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/AddExtensionsMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/AddExtensionsMojo.java
@@ -1,0 +1,14 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Allow adding extensions to an existing pom.xml file.
+ * Because you can add one or several extension in one go, there are 2 mojos:
+ * {@code add-extensions} and {@code add-extension}. Both supports the {@code extension} and {@code extensions}
+ * parameters.
+ */
+@Mojo(name = "add-extensions")
+public class AddExtensionsMojo extends AddExtensionMojo {
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/AnalyseCallTreeMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/AnalyseCallTreeMojo.java
@@ -1,0 +1,57 @@
+package io.quarkus.maven;
+
+import java.io.File;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.deployment.pkg.steps.ReportAnalyzer;
+
+/**
+ * Analyze call tree of a method or a class based on an existing report produced by Substrate when using
+ * -H:+PrintAnalysisCallTree,
+ * and does a more meaningful analysis of what is causing a type to be retained.
+ */
+@Mojo(name = "analyze-call-tree")
+public class AnalyseCallTreeMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${class}")
+    private String className;
+
+    @Parameter(defaultValue = "${method}")
+    private String methodName;
+
+    @Parameter(defaultValue = "${project.build.directory}/reports")
+    private File reportsDir;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (methodName != null && className != null) {
+            throw new MojoFailureException("Cannot specify both class and method name");
+        }
+        String clazz = className;
+        String method = "<init>";
+        if (methodName != null) {
+            int index = methodName.lastIndexOf('.');
+            clazz = methodName.substring(0, index);
+            method = methodName.substring(index + 1);
+        }
+
+        File[] files = reportsDir.listFiles();
+        if (files == null) {
+            throw new MojoFailureException("No reports in " + reportsDir);
+        }
+        for (File i : files) {
+            if (i.getName().startsWith("call_tree")) {
+                try {
+                    System.out.println(new ReportAnalyzer(i.getAbsolutePath()).analyse(clazz, method));
+                } catch (Exception e) {
+                    throw new MojoExecutionException("Failed", e);
+                }
+            }
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/BuildMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/BuildMojo.java
@@ -1,0 +1,183 @@
+package io.quarkus.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.app.AugmentAction;
+import io.quarkus.bootstrap.app.AugmentResult;
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.util.IoUtils;
+
+/**
+ * Builds the Quarkus application.
+ */
+@Mojo(name = "build", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class BuildMojo extends QuarkusBootstrapMojo {
+
+    private static final String PACKAGE_TYPE_PROP = "quarkus.package.type";
+    private static final String NATIVE_PROFILE_NAME = "native";
+    private static final String NATIVE_PACKAGE_TYPE = "native";
+
+    @Component
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The project's remote repositories to use for the resolution of plugins and their dependencies.
+     */
+    @Parameter(defaultValue = "${project.remotePluginRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> pluginRepos;
+
+    /**
+     * The directory for generated source files.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/generated-sources")
+    private File generatedSourcesDirectory;
+
+    /**
+     * Skips the execution of this mojo
+     */
+    @Parameter(defaultValue = "false", property = "quarkus.build.skip")
+    private boolean skip = false;
+
+    @Deprecated
+    @Parameter(property = "skipOriginalJarRename")
+    boolean skipOriginalJarRename;
+
+    /**
+     * The list of system properties defined for the plugin.
+     */
+    @Parameter
+    private Map<String, String> systemProperties = Collections.emptyMap();
+
+    @Override
+    protected boolean beforeExecute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("Skipping Quarkus build");
+            return false;
+        }
+        if (mavenProject().getPackaging().equals("pom")) {
+            getLog().info("Type of the artifact is POM, skipping build goal");
+            return false;
+        }
+        if (!mavenProject().getArtifact().getArtifactHandler().getExtension().equals("jar")) {
+            throw new MojoExecutionException(
+                    "The project artifact's extension is '" + mavenProject().getArtifact().getArtifactHandler().getExtension()
+                            + "' while this goal expects it be 'jar'");
+        }
+        return true;
+    }
+
+    @Override
+    protected void doExecute() throws MojoExecutionException {
+        try {
+            Set<String> propertiesToClear = new HashSet<>();
+
+            // Add the system properties of the plugin to the system properties
+            // if and only if they are not already set.
+            for (Map.Entry<String, String> entry : systemProperties.entrySet()) {
+                String key = entry.getKey();
+                if (System.getProperty(key) == null) {
+                    System.setProperty(key, entry.getValue());
+                    propertiesToClear.add(key);
+                }
+            }
+
+            // Essentially what this does is to enable the native package type even if a different package type is set
+            // in application properties. This is done to preserve what users expect to happen when
+            // they execute "mvn package -Dnative" even if quarkus.package.type has been set in application.properties
+            if (!System.getProperties().containsKey(PACKAGE_TYPE_PROP)
+                    && isNativeProfileEnabled(mavenProject())) {
+                Object packageTypeProp = mavenProject().getProperties().get(PACKAGE_TYPE_PROP);
+                String packageType = NATIVE_PACKAGE_TYPE;
+                if (packageTypeProp != null) {
+                    packageType = packageTypeProp.toString();
+                }
+                System.setProperty(PACKAGE_TYPE_PROP, packageType);
+                propertiesToClear.add(PACKAGE_TYPE_PROP);
+            }
+            if (!propertiesToClear.isEmpty() && mavenSession().getRequest().getDegreeOfConcurrency() > 1) {
+                getLog().warn("*****************************************************************");
+                getLog().warn("* Your build is requesting parallel execution, but the project  *");
+                getLog().warn("* relies on System properties at build time which could cause   *");
+                getLog().warn("* race condition issues thus unpredictable build results.       *");
+                getLog().warn("* Please avoid using System properties or avoid enabling        *");
+                getLog().warn("* parallel execution                                            *");
+                getLog().warn("*****************************************************************");
+            }
+            try (CuratedApplication curatedApplication = bootstrapApplication()) {
+
+                AugmentAction action = curatedApplication.createAugmentor();
+                AugmentResult result = action.createProductionApplication();
+
+                Artifact original = mavenProject().getArtifact();
+                if (result.getJar() != null) {
+
+                    if (!skipOriginalJarRename && result.getJar().isUberJar()
+                            && result.getJar().getOriginalArtifact() != null) {
+                        final Path standardJar = result.getJar().getOriginalArtifact();
+                        if (Files.exists(standardJar)) {
+                            final Path renamedOriginal = standardJar.getParent().toAbsolutePath()
+                                    .resolve(standardJar.getFileName() + ".original");
+                            try {
+                                IoUtils.recursiveDelete(renamedOriginal);
+                                Files.move(standardJar, renamedOriginal);
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                            original.setFile(result.getJar().getOriginalArtifact().toFile());
+                        }
+                    }
+                    if (result.getJar().isUberJar()) {
+                        projectHelper.attachArtifact(mavenProject(), result.getJar().getPath().toFile(),
+                                result.getJar().getClassifier());
+                    }
+                }
+            } finally {
+                // Clear all the system properties set by the plugin
+                propertiesToClear.forEach(System::clearProperty);
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to build quarkus application", e);
+        }
+    }
+
+    private boolean isNativeProfileEnabled(MavenProject mavenProject) {
+        // gotcha: mavenProject.getActiveProfiles() does not always contain all active profiles (sic!),
+        //         but getInjectedProfileIds() does (which has to be "flattened" first)
+        Stream<String> activeProfileIds = mavenProject.getInjectedProfileIds().values().stream().flatMap(List<String>::stream);
+        if (activeProfileIds.anyMatch(NATIVE_PROFILE_NAME::equalsIgnoreCase)) {
+            return true;
+        }
+        // recurse into parent (if available)
+        return Optional.ofNullable(mavenProject.getParent()).map(this::isNativeProfileEnabled).orElse(false);
+    }
+
+    @Override
+    public void setLog(Log log) {
+        super.setLog(log);
+        MojoLogger.delegate = log;
+    }
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CheckForUpdatesMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CheckForUpdatesMojo.java
@@ -1,0 +1,440 @@
+package io.quarkus.maven;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.maven.utilities.MojoUtils;
+import io.quarkus.platform.tools.maven.MojoMessageWriter;
+import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.ExtensionOrigin;
+import io.quarkus.registry.catalog.selection.ExtensionOrigins;
+import io.quarkus.registry.catalog.selection.OriginCombination;
+import io.quarkus.registry.catalog.selection.OriginPreference;
+import io.quarkus.registry.catalog.selection.OriginSelector;
+import io.quarkus.registry.util.PlatformArtifacts;
+
+/**
+ * NOTE: this mojo is experimental
+ */
+@Mojo(name = "check-for-updates", requiresProject = true)
+public class CheckForUpdatesMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}")
+    protected MavenProject project;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Component
+    RemoteRepositoryManager remoteRepoManager;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        getLog().warn(
+                "This goal is experimental. Its name, parameters, output and implementation will be evolving without the promise of keeping backward compatibility");
+
+        if (project.getFile() == null) {
+            throw new MojoExecutionException("This goal requires a project");
+        }
+
+        if (!QuarkusProjectHelper.isRegistryClientEnabled()) {
+            throw new MojoExecutionException("This goal requires a Quarkus extension registry client to be enabled");
+        }
+
+        final Map<ArtifactKey, String> previousExtensions = getDirectExtensionDependencies();
+        if (previousExtensions.isEmpty()) {
+            getLog().info("The project does not appear to depend on any Quarkus extension directly");
+            return;
+        }
+
+        final MavenArtifactResolver mvn;
+        try {
+            mvn = MavenArtifactResolver.builder()
+                    .setRepositorySystem(repoSystem)
+                    .setRepositorySystemSession(
+                            getLog().isDebugEnabled() ? repoSession : MojoUtils.muteTransferListener(repoSession))
+                    .setRemoteRepositories(repos)
+                    .setRemoteRepositoryManager(remoteRepoManager)
+                    .build();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
+        }
+        final MojoMessageWriter log = new MojoMessageWriter(getLog());
+        final ExtensionCatalogResolver catalogResolver;
+        try {
+            catalogResolver = QuarkusProjectHelper.getCatalogResolver(mvn, log);
+        } catch (RegistryResolutionException e) {
+            throw new MojoExecutionException("Failed to initialize Quarkus extension registry client", e);
+        }
+
+        if (!catalogResolver.hasRegistries()) {
+            throw new MojoExecutionException("Configured Quarkus extension registries aren't available");
+        }
+
+        final ExtensionCatalog latestCatalog;
+        try {
+            latestCatalog = catalogResolver.resolveExtensionCatalog();
+        } catch (RegistryResolutionException e) {
+            throw new MojoExecutionException(
+                    "Failed to resolve the latest Quarkus extension catalog from the configured extension registries", e);
+        }
+
+        final Map<ArtifactKey, Extension> recommendedExtensionMap = new HashMap<>(latestCatalog.getExtensions().size());
+        final Map<String, List<ArtifactKey>> recommendedExtensionsByOrigin = new HashMap<>();
+        for (Extension e : latestCatalog.getExtensions()) {
+            recommendedExtensionMap.put(e.getArtifact().getKey(), e);
+            for (ExtensionOrigin origin : e.getOrigins()) {
+                recommendedExtensionsByOrigin.computeIfAbsent(origin.getId(), k -> new ArrayList<>())
+                        .add(e.getArtifact().getKey());
+            }
+        }
+
+        final List<ArtifactKey> notAvailableExtensions = new ArrayList<>(0);
+        final List<Extension> recommendedExtensions = new ArrayList<>(previousExtensions.size());
+        for (ArtifactKey key : previousExtensions.keySet()) {
+            final Extension e = recommendedExtensionMap.get(key);
+            if (e == null) {
+                notAvailableExtensions.add(key);
+            } else {
+                recommendedExtensions.add(e);
+            }
+        }
+
+        if (!notAvailableExtensions.isEmpty()) {
+            final StringWriter buf = new StringWriter();
+            try (BufferedWriter writer = new BufferedWriter(buf)) {
+                writer.append(
+                        "Could not find any information about the following extensions in the currently configured registries: ");
+                writer.newLine();
+                writer.append(" - ").append(notAvailableExtensions.get(0).toGacString());
+                for (int i = 1; i < notAvailableExtensions.size(); ++i) {
+                    writer.newLine();
+                    writer.append(" - ").append(notAvailableExtensions.get(i).toGacString());
+                }
+            } catch (IOException e) {
+                getLog().warn("Failed to compose a warning message", e);
+            }
+            getLog().warn(buf.toString());
+            return;
+        }
+
+        final List<ExtensionCatalog> recommendedOrigins;
+        try {
+            recommendedOrigins = getRecommendedOrigins(latestCatalog, recommendedExtensions);
+        } catch (QuarkusCommandException e) {
+            getLog().warn(e.getLocalizedMessage());
+            return;
+        }
+
+        ArtifactCoords rhUniverseBom = null;
+        ArtifactCoords rhProdBom = null;
+        final List<ArtifactCoords> previousBomImports = new ArrayList<>();
+        for (Dependency d : project.getDependencyManagement().getDependencies()) {
+            if (!PlatformArtifacts.isCatalogArtifactId(d.getArtifactId())) {
+                continue;
+            }
+            final ArtifactCoords platformBomCoords = new ArtifactCoords(d.getGroupId(),
+                    PlatformArtifacts.ensureBomArtifactId(d.getArtifactId()), "pom", d.getVersion());
+            if (d.getArtifactId().startsWith("quarkus-universe-bom-")) {
+                // in pre-2.x quarkus versions, the quarkus-bom descriptor would show up as a
+                // parent of the quarkus-universe-bom one
+                // even if it was not actually imported, so here we simply remove it, if it was
+                // found
+                previousBomImports.remove(new ArtifactCoords(platformBomCoords.getGroupId(), "quarkus-bom", "pom",
+                        platformBomCoords.getVersion()));
+
+                if (platformBomCoords.getVersion().contains("-redhat-")) {
+                    rhUniverseBom = platformBomCoords;
+                } else if (rhUniverseBom != null && platformBomCoords.getVersion().regionMatches(0, rhUniverseBom.getVersion(),
+                        0, rhUniverseBom.getVersion().length() - 1 - rhUniverseBom.getVersion().indexOf("-redhat-"))) {
+                    continue;
+                }
+            } else if (d.getArtifactId().startsWith("quarkus-product-bom-")) {
+                // rhbq 1.x filtering
+                rhProdBom = platformBomCoords;
+                if (previousBomImports.contains(new ArtifactCoords(platformBomCoords.getGroupId(),
+                        "quarkus-universe-bom", "pom", platformBomCoords.getVersion()))) {
+                    continue;
+                }
+            } else if (rhProdBom != null && platformBomCoords.getVersion().equals(rhProdBom.getVersion()) // rhbq 1.x filtering
+                    && platformBomCoords.getArtifactId().equals("quarkus-bom")) {
+                continue;
+            }
+            previousBomImports.add(platformBomCoords);
+        }
+
+        final List<ArtifactCoords> recommendedBomImports = new ArrayList<>();
+        final Map<ArtifactCoords, String> nonPlatformUpdates = new LinkedHashMap<>(0);
+
+        for (ExtensionCatalog origin : recommendedOrigins) {
+            if (origin.isPlatform()) {
+                if (!previousBomImports.remove(origin.getBom())) {
+                    recommendedBomImports.add(origin.getBom());
+                }
+                for (ArtifactKey extKey : recommendedExtensionsByOrigin.getOrDefault(origin.getId(), Collections.emptyList())) {
+                    previousExtensions.remove(extKey);
+                }
+            } else {
+                for (ArtifactKey extKey : recommendedExtensionsByOrigin.getOrDefault(origin.getId(), Collections.emptyList())) {
+                    final Extension recommendedExt = recommendedExtensionMap.get(extKey);
+                    final String prevVersion = previousExtensions.remove(extKey);
+                    if (prevVersion != null && !prevVersion.equals(recommendedExt.getArtifact().getVersion())) {
+                        nonPlatformUpdates.put(recommendedExt.getArtifact(), prevVersion);
+                    }
+                }
+            }
+        }
+
+        if (recommendedBomImports.isEmpty() && nonPlatformUpdates.isEmpty()) {
+            log.info("The project is up-to-date");
+            return;
+        }
+
+        ArtifactCoords prevPluginCoords = null;
+        for (Plugin p : project.getBuildPlugins()) {
+            if (p.getArtifactId().equals("quarkus-maven-plugin")) {
+                prevPluginCoords = new ArtifactCoords(p.getGroupId(), p.getArtifactId(), p.getVersion());
+                break;
+            }
+        }
+
+        ExtensionCatalog core = null;
+        for (ExtensionOrigin o : recommendedOrigins) {
+            if (o.isPlatform() && o.getBom().getArtifactId().equals("quarkus-bom")) {
+                core = (ExtensionCatalog) o;
+            }
+        }
+
+        ArtifactCoords recommendedPluginCoords = null;
+        if (core != null) {
+            final Map<String, ?> props = (Map<String, ?>) ((Map<String, Object>) core.getMetadata().getOrDefault("project",
+                    Collections.emptyMap())).getOrDefault("properties", Collections.emptyMap());
+            final String pluginGroupId = (String) props.get("maven-plugin-groupId");
+            final String pluginArtifactId = (String) props.get("maven-plugin-artifactId");
+            final String pluginVersion = (String) props.get("maven-plugin-version");
+            if (pluginGroupId == null || pluginArtifactId == null || pluginVersion == null) {
+                log.warn("Failed to locate the recommended Quarkus Maven plugin coordinates");
+            } else {
+                recommendedPluginCoords = new ArtifactCoords(pluginGroupId, pluginArtifactId, pluginVersion);
+            }
+        }
+
+        final StringWriter buf = new StringWriter();
+        try (BufferedWriter writer = new BufferedWriter(buf)) {
+
+            writer.append("Currently recommended updates for the application include:");
+            writer.newLine();
+            writer.newLine();
+
+            if (!previousBomImports.isEmpty()) {
+                writer.append(" * BOM imports to be replaced:");
+                writer.newLine();
+                writer.newLine();
+                for (ArtifactCoords bom : previousBomImports) {
+                    logBomImport(writer, bom);
+                }
+                writer.newLine();
+            }
+
+            if (!recommendedBomImports.isEmpty()) {
+                writer.append(" * New recommended BOM imports:");
+                writer.newLine();
+                writer.newLine();
+                for (ArtifactCoords bom : recommendedBomImports) {
+                    logBomImport(writer, bom);
+                }
+                writer.newLine();
+            }
+
+            if (!nonPlatformUpdates.isEmpty()) {
+                writer.append(" * New recommended extension versions (not managed by the BOMs):");
+                writer.newLine();
+                writer.newLine();
+
+                for (ArtifactCoords coords : nonPlatformUpdates.keySet()) {
+                    writer.append("    <dependency>");
+                    writer.newLine();
+                    writer.append("      <groupId>").append(coords.getGroupId()).append("</groupId>");
+                    writer.newLine();
+                    writer.append("      <artifactId>").append(coords.getArtifactId()).append("</artifactId>");
+                    writer.newLine();
+                    writer.append("      <version>").append(coords.getVersion()).append("</version>");
+                    writer.newLine();
+                    writer.append("    </dependency>");
+                    writer.newLine();
+                }
+                writer.newLine();
+            }
+
+            if (prevPluginCoords != null && recommendedPluginCoords != null
+                    && !prevPluginCoords.equals(recommendedPluginCoords)) {
+                writer.append(" * Recommended Quarkus Maven plugin:");
+                writer.newLine();
+                writer.newLine();
+                writer.append("      <plugin>");
+                writer.newLine();
+                writer.append("        <groupId>").append(recommendedPluginCoords.getGroupId()).append("</groupId>");
+                writer.newLine();
+                writer.append("        <artifactId>").append(recommendedPluginCoords.getArtifactId()).append("</artifactId>");
+                writer.newLine();
+                writer.append("        <version>").append(recommendedPluginCoords.getVersion()).append("</version>");
+                writer.newLine();
+                writer.append("      </plugin>");
+                writer.newLine();
+
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to compose the update report", e);
+        }
+
+        getLog().info(buf.toString());
+    }
+
+    private void logBomImport(BufferedWriter writer, ArtifactCoords bom) throws IOException {
+        writer.append("      <dependency>");
+        writer.newLine();
+        writer.append("        <groupId>").append(bom.getGroupId()).append("</groupId>");
+        writer.newLine();
+        writer.append("        <artifactId>").append(bom.getArtifactId()).append("</artifactId>");
+        writer.newLine();
+        writer.append("        <version>").append(bom.getVersion()).append("</version>");
+        writer.newLine();
+        writer.append("        <type>pom</type>");
+        writer.newLine();
+        writer.append("        <scope>import</scope>");
+        writer.newLine();
+        writer.append("      </dependency>");
+        writer.newLine();
+    }
+
+    private Map<ArtifactKey, String> getDirectExtensionDependencies() throws MojoExecutionException {
+        final List<Dependency> modelDeps = project.getModel().getDependencies();
+        final List<ArtifactRequest> requests = new ArrayList<>(modelDeps.size());
+        for (Dependency d : modelDeps) {
+            if ("jar".equals(d.getType())) {
+                requests.add(new ArtifactRequest().setArtifact(
+                        new DefaultArtifact(d.getGroupId(), d.getArtifactId(), d.getClassifier(), d.getType(), d.getVersion()))
+                        .setRepositories(repos));
+            }
+        }
+        final List<ArtifactResult> artifactResults;
+        try {
+            artifactResults = repoSystem.resolveArtifacts(repoSession, requests);
+        } catch (ArtifactResolutionException e) {
+            throw new MojoExecutionException("Failed to resolve project dependencies", e);
+        }
+        final Map<ArtifactKey, String> extensions = new HashMap<>(artifactResults.size());
+        for (ArtifactResult ar : artifactResults) {
+            final Artifact a = ar.getArtifact();
+            if (isExtension(a.getFile().toPath())) {
+                extensions.put(new ArtifactKey(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension()),
+                        a.getVersion());
+            }
+        }
+        return extensions;
+    }
+
+    private static boolean isExtension(Path p) throws MojoExecutionException {
+        if (!Files.exists(p)) {
+            throw new MojoExecutionException("Extension artifact " + p + " does not exist");
+        }
+        if (Files.isDirectory(p)) {
+            return Files.exists(p.resolve(BootstrapConstants.DESCRIPTOR_PATH));
+        } else {
+            try (FileSystem fs = FileSystems.newFileSystem(p, (ClassLoader) null)) {
+                return Files.exists(fs.getPath(BootstrapConstants.DESCRIPTOR_PATH));
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to read archive " + p, e);
+            }
+        }
+    }
+
+    private static List<ExtensionCatalog> getRecommendedOrigins(ExtensionCatalog extensionCatalog, List<Extension> extensions)
+            throws QuarkusCommandException {
+        final List<ExtensionOrigins> extOrigins = new ArrayList<>(extensions.size());
+        for (Extension e : extensions) {
+            addOrigins(extOrigins, e);
+        }
+        final OriginSelector os = new OriginSelector(extOrigins);
+        os.calculateCompatibleCombinations();
+
+        final OriginCombination recommendedCombination = os.getRecommendedCombination();
+        if (recommendedCombination == null) {
+            final StringBuilder buf = new StringBuilder();
+            buf.append("Failed to determine a compatible Quarkus version for the requested extensions: ");
+            buf.append(extensions.get(0).getArtifact().getKey().toGacString());
+            for (int i = 1; i < extensions.size(); ++i) {
+                buf.append(", ").append(extensions.get(i).getArtifact().getKey().toGacString());
+            }
+            throw new QuarkusCommandException(buf.toString());
+        }
+        return recommendedCombination.getUniqueSortedOrigins().stream().map(o -> o.getCatalog()).collect(Collectors.toList());
+    }
+
+    private static void addOrigins(final List<ExtensionOrigins> extOrigins, Extension e) {
+        ExtensionOrigins.Builder eoBuilder = null;
+        for (ExtensionOrigin o : e.getOrigins()) {
+            if (!(o instanceof ExtensionCatalog)) {
+                continue;
+            }
+            final ExtensionCatalog c = (ExtensionCatalog) o;
+            final OriginPreference op = (OriginPreference) c.getMetadata().get("origin-preference");
+            if (op == null) {
+                continue;
+            }
+            if (eoBuilder == null) {
+                eoBuilder = ExtensionOrigins.builder(e.getArtifact().getKey());
+            }
+            eoBuilder.addOrigin(c, op);
+        }
+        if (eoBuilder != null) {
+            extOrigins.add(eoBuilder.build());
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateExtensionLegacyMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateExtensionLegacyMojo.java
@@ -1,0 +1,1289 @@
+package io.quarkus.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.lang.model.SourceVersion;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.jboss.logging.Logger;
+
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.FileTemplateLoader;
+import freemarker.cache.MultiTemplateLoader;
+import freemarker.cache.TemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateExceptionHandler;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.maven.utilities.MojoUtils;
+import io.quarkus.maven.utilities.PomTransformer;
+import io.quarkus.maven.utilities.PomTransformer.Gavtcs;
+import io.quarkus.maven.utilities.PomTransformer.Transformation;
+
+/**
+ * LEGACY COMMAND
+ *
+ * Creates a triple of stub Maven modules (Parent, Runtime and Deployment) to implement a new
+ * <a href="https://quarkus.io/guides/writing-extensions">Quarkus Extension</a>.
+ *
+ * <h2>Adding into an established source tree</h2>
+ * <p>
+ * If this Mojo is executed in a directory that contains a {@code pom.xml} file with packaging {@code pom} the newly
+ * created Parent module is added as a child module to the existing {@code pom.xml} file.
+ *
+ * <h2>Creating a source tree from scratch</h2>
+ * <p>
+ * Executing this Mojo in an empty directory is not supported yet.
+ */
+@Mojo(name = "create-extension-legacy", requiresProject = false)
+public class CreateExtensionLegacyMojo extends AbstractMojo {
+
+    private static final String QUOTED_DOLLAR = Matcher.quoteReplacement("$");
+
+    private static final Logger log = Logger.getLogger(CreateExtensionLegacyMojo.class);
+
+    private static final Pattern BRACKETS_PATTERN = Pattern.compile("[()]+");
+    private static final String CLASSPATH_PREFIX = "classpath:";
+    private static final String FILE_PREFIX = "file:";
+
+    private static final String QUARKUS_VERSION_PROP = "quarkus.version";
+
+    static final String DEFAULT_ENCODING = "utf-8";
+    static final String DEFAULT_QUARKUS_VERSION = "@{" + QUARKUS_VERSION_PROP + "}";
+    static final String QUARKUS_VERSION_POM_EXPR = "${" + QUARKUS_VERSION_PROP + "}";
+    static final String DEFAULT_BOM_ENTRY_VERSION = "@{project.version}";
+    static final String DEFAULT_TEMPLATES_URI_BASE = "classpath:/create-extension-templates";
+    static final String DEFAULT_NAME_SEGMENT_DELIMITER = " - ";
+    static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("@\\{([^\\}]+)\\}");
+
+    static final String PLATFORM_DEFAULT_GROUP_ID = "io.quarkus";
+    static final String PLATFORM_DEFAULT_ARTIFACT_ID = "quarkus-bom";
+
+    static final String COMPILER_PLUGIN_VERSION_PROP = "compiler-plugin.version";
+    static final String COMPILER_PLUGIN_VERSION_POM_EXPR = "${" + COMPILER_PLUGIN_VERSION_PROP + "}";
+    static final String COMPILER_PLUGIN_DEFAULT_VERSION = "3.8.1";
+    private static final String COMPILER_PLUGIN_GROUP_ID = "org.apache.maven.plugins";
+    private static final String COMPILER_PLUGIN_ARTIFACT_ID = "maven-compiler-plugin";
+    private static final String COMPILER_PLUGIN_KEY = COMPILER_PLUGIN_GROUP_ID + ":"
+            + COMPILER_PLUGIN_ARTIFACT_ID;
+
+    /**
+     * Directory where the changes should be performed. Default is the current directory of the current Java process.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.basedir")
+    File basedir;
+
+    /**
+     * The {@code groupId} of the Quarkus platform BOM.
+     */
+    @Parameter(property = "platformGroupId", defaultValue = PLATFORM_DEFAULT_GROUP_ID)
+    String platformGroupId;
+
+    /**
+     * The {@code artifactId} of the Quarkus platform BOM.
+     */
+    @Parameter(property = "platformArtifactId", defaultValue = PLATFORM_DEFAULT_ARTIFACT_ID)
+    String platformArtifactId;
+
+    /**
+     * The {@code groupId} for the newly created Maven modules. If {@code groupId} is left unset, the {@code groupId}
+     * from the {@code pom.xml} in the current directory will be used. Otherwise, an exception is thrown.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "groupId")
+    String groupId;
+
+    /**
+     * This parameter was introduced to change the property of {@code groupId} parameter from {@code quarkus.groupId} to
+     * {@code groupId}
+     *
+     * @since 1.3.0
+     */
+    @Deprecated
+    @Parameter(property = "quarkus.groupId")
+    String deprecatedGroupId;
+
+    /**
+     * {@code artifactId} of the runtime module. The {@code artifactId}s of the extension parent
+     * (<code>${artifactId}-parent</code>) and deployment (<code>${artifactId}-deployment</code>) modules will be based
+     * on this {@code artifactId} too.
+     * <p>
+     * Optionally, this value can contain the {@link #artifactIdBase} enclosed in round brackets, e.g.
+     * {@code my-project-(cool-extension)}, where {@code cool-extension} is an {@link #artifactIdBase} and
+     * {@code my-project-} is {@link #artifactIdPrefix}. This is a way to avoid defining of {@link #artifactIdPrefix}
+     * and {@link #artifactIdBase} separately. If no round brackets are present in {@link #artifactId},
+     * {@link #artifactIdBase} will be equal to {@link #artifactId} and {@link #artifactIdPrefix} will be an empty
+     * string.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "artifactId")
+    String artifactId;
+
+    /**
+     * This parameter was introduced to change the property of {@code artifactId} parameter from {@code quarkus.artifactId} to
+     * {@code artifactId}
+     *
+     * @since 1.3.0
+     */
+    @Deprecated
+    @Parameter(property = "quarkus.artifactId")
+    String deprecatedArtifactId;
+
+    /**
+     * A prefix common to all extension artifactIds in the current source tree. If you set {@link #artifactIdPrefix},
+     * set also {@link #artifactIdBase}, but do not set {@link #artifactId}.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.artifactIdPrefix", defaultValue = "")
+    String artifactIdPrefix;
+
+    /**
+     * The unique part of the {@link #artifactId}. If you set {@link #artifactIdBase}, {@link #artifactIdPrefix}
+     * may also be set, but not {@link #artifactId}.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.artifactIdBase")
+    String artifactIdBase;
+
+    /**
+     * The {@code version} for the newly created Maven modules. If {@code version} is left unset, the {@code version}
+     * from the {@code pom.xml} in the current directory will be used. Otherwise, an exception is thrown.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "version")
+    String version;
+
+    /**
+     * This parameter was introduced to change the property of {@code version} parameter from {@code quarkus.artifactVersion} to
+     * {@code version}
+     *
+     * @since 1.3.0
+     */
+    @Deprecated
+    @Parameter(property = "quarkus.artifactVersion")
+    String deprecatedVersion;
+
+    /**
+     * The {@code name} of the runtime module. The {@code name}s of the extension parent and deployment modules will be
+     * based on this {@code name} too.
+     * <p>
+     * Optionally, this value can contain the {@link #nameBase} enclosed in round brackets, e.g.
+     * {@code My Project - (Cool Extension)}, where {@code Cool Extension} is a {@link #nameBase} and
+     * {@code My Project - } is {@link #namePrefix}. This is a way to avoid defining of {@link #namePrefix} and
+     * {@link #nameBase} separately. If no round brackets are present in {@link #name}, the {@link #nameBase} will be
+     * equal to {@link #name} and {@link #namePrefix} will be an empty string.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.name")
+    String name;
+
+    /**
+     * A prefix common to all extension names in the current source tree. If you set {@link #namePrefix}, set also
+     * {@link #nameBase}, but do not set {@link #name}.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.namePrefix")
+    String namePrefix;
+
+    /**
+     * The unique part of the {@link #name}. If you set {@link #nameBase}, set also {@link #namePrefix}, but do not set
+     * {@link #name}.
+     * <p>
+     * If neither {@link #name} nor @{link #nameBase} is set, @{link #nameBase} will be derived from
+     * {@link #artifactIdBase}.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.nameBase")
+    String nameBase;
+
+    /**
+     * A string that will delimit {@link #name} from {@code Parent}, {@code Runtime} and {@code Deployment} tokens in
+     * the respective modules.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.nameSegmentDelimiter", defaultValue = DEFAULT_NAME_SEGMENT_DELIMITER)
+    String nameSegmentDelimiter;
+
+    /**
+     * Base Java package under which Java classes should be created in Runtime and Deployment modules. If not set, the
+     * Java package will be auto-generated out of {@link #groupId}, {@link #javaPackageInfix} and {@link #artifactId}
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.javaPackageBase")
+    String javaPackageBase;
+
+    /**
+     * If {@link #javaPackageBase} is not set explicitly, this infix will be put between package segments taken from
+     * {@link #groupId} and {@link #artifactId}.
+     * <p>
+     * Example: Given
+     * <ul>
+     * <li>{@link #groupId} is {@code org.example.quarkus.extensions}</li>
+     * <li>{@link #javaPackageInfix} is {@code foo.bar}</li>
+     * <li>{@link #artifactId} is {@code cool-extension}</li>
+     * </ul>
+     * Then the auto-generated {@link #javaPackageBase} will be
+     * {@code org.example.quarkus.extensions.foo.bar.cool.extension}
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.javaPackageInfix")
+    String javaPackageInfix;
+
+    /**
+     * This mojo creates a triple of Maven modules (Parent, Runtime and Deployment). "Grand parent" is the parent of the
+     * Parent module. If {@code grandParentArtifactId} is left unset, the {@code artifactId} from the {@code pom.xml} in
+     * the current directory will be used. Otherwise, an exception is thrown.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.grandParentArtifactId")
+    @Deprecated
+    String grandParentArtifactId;
+
+    /**
+     * This mojo creates a Maven project consisting of the root POM and two modules: the runtime and the deployment one.
+     * This parameter configures the {@code artifactId} of the root POM's parent POM.
+     * If {@code parentArtifactId} is left unset, then if the current directory already includes a {@code pom.xml}
+     * its {@code artifactId} will be used as the parent's {@code artifactId} and if the current directory does not contain
+     * any {@code pom.xml} then the generated root {@code pom.xml} won't have any parent.
+     */
+    @Parameter(property = "parentArtifactId")
+    String parentArtifactId;
+
+    /**
+     * This mojo creates a triple of Maven modules (Parent, Runtime and Deployment). "Grand parent" is the parent of the
+     * Parent module. If {@code grandParentGroupId} is left unset, the {@code groupId} from the {@code pom.xml} in the
+     * current directory will be used. Otherwise, an exception is thrown.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.grandParentGroupId")
+    @Deprecated
+    String grandParentGroupId;
+
+    /**
+     * This mojo creates a Maven project consisting of the root POM and two modules: the runtime and the deployment one.
+     * This parameter configures the {@code groupId} of the root POM's parent POM.
+     * If {@code parentGroupId} is left unset, then if the current directory already includes a {@code pom.xml}
+     * its {@code groupId} will be used as the parent's {@code groupId} and if the current directory does not contain
+     * any {@code pom.xml} then the generated root {@code pom.xml} won't have any parent.
+     */
+    @Parameter(property = "parentGroupId")
+    String parentGroupId;
+
+    /**
+     * This mojo creates a triple of Maven modules (Parent, Runtime and Deployment). "Grand parent" is the parent of the
+     * Parent module. If {@code grandParentRelativePath} is left unset, the default {@code relativePath}
+     * {@code "../pom.xml"} is used.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.grandParentRelativePath")
+    @Deprecated
+    String grandParentRelativePath;
+
+    /**
+     * This mojo creates a Maven project consisting of the root POM and two modules: the runtime and the deployment one.
+     * This parameter configures the {@code relativePath} of the root POM's parent POM.
+     * If {@code grandParentRelativePath} is left unset, the default {@code relativePath} is used.
+     */
+    @Parameter(property = "parentRelativePath")
+    String parentRelativePath;
+
+    /**
+     * This mojo creates a triple of Maven modules (Parent, Runtime and Deployment). "Grand parent" is the parent of the
+     * Parent module. If {@code grandParentVersion} is left unset, the {@code version} from the {@code pom.xml} in the
+     * current directory will be used. Otherwise, an exception is thrown.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.grandParentVersion")
+    @Deprecated
+    String grandParentVersion;
+
+    /**
+     * This mojo creates a Maven project consisting of the root POM and two modules: the runtime and the deployment one.
+     * This parameter configures the {@code version} of the root POM's parent POM.
+     * If {@code parentVersion} is left unset, then if the current directory already includes a {@code pom.xml}
+     * its {@code version} will be used as the parent's {@code version} and if the current directory does not contain
+     * any {@code pom.xml} then the generated root {@code pom.xml} won't have any parent.
+     */
+    @Parameter(property = "parentVersion")
+    String parentVersion;
+
+    /**
+     * Quarkus version the newly created extension should depend on. If you want to pass a property placeholder, use
+     * {@code @} instead if {@code $} so that the property is not evaluated by the current mojo - e.g.
+     * <code>@{quarkus.version}</code>
+     *
+     * @since 0.20.0
+     */
+    @Parameter(defaultValue = DEFAULT_QUARKUS_VERSION, required = true, property = "quarkus.version")
+    String quarkusVersion;
+
+    /**
+     * This parameter was introduced to change the property of {@code artifactId} parameter from {@code quarkus.artifactId} to
+     * {@code artifactId}
+     *
+     * @since 1.3.0
+     */
+    @Deprecated
+    @Parameter(property = "quarkus.quarkusVersion")
+    String deprecatedQuarkusVersion;
+
+    /**
+     * If {@code true} the Maven dependencies in Runtime and Deployment modules will not have their versions set and the
+     * {@code quarkus-bootstrap-maven-plugin} in the Runtime module will not have its version set and it will have no
+     * executions configured. If {@code false} the version set in {@link #quarkusVersion} will be used where applicable
+     * and {@code quarkus-bootstrap-maven-plugin} in the Runtime module will be configured explicitly. If the value is
+     * {@code null} the parameter will be treated as it was initialized to {@code false}.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(property = "quarkus.assumeManaged")
+    Boolean assumeManaged;
+
+    /**
+     * URI prefix to use when looking up FreeMarker templates when generating various source files. You need to touch
+     * this only if you want to provide your own custom templates.
+     * <p>
+     * The following URI schemes are supported:
+     * <ul>
+     * <li>{@code classpath:}</li>
+     * <li>{@code file:} (relative to {@link #basedir})</li>
+     * </ul>
+     * These are the template files you may want to provide under your custom {@link #templatesUriBase}:
+     * <ul>
+     * <li>{@code deployment-pom.xml}</li>
+     * <li>{@code integration-test-application.properties}</li>
+     * <li>{@code integration-test-pom.xml}</li>
+     * <li>{@code IT.java}</li>
+     * <li>{@code parent-pom.xml}</li>
+     * <li>{@code Processor.java}</li>
+     * <li>{@code runtime-pom.xml}</li>
+     * <li>{@code Test.java}</li>
+     * <li>{@code TestResource.java}</li>
+     * </ul>
+     * Note that you do not need to provide all of them. Files not available in your custom {@link #templatesUriBase}
+     * will be looked up in the default URI base {@value #DEFAULT_TEMPLATES_URI_BASE}. The default templates are
+     * maintained <a href=
+     * "https://github.com/quarkusio/quarkus/tree/main/devtools/maven/src/main/resources/create-extension-templates">here</a>.
+     *
+     * @since 0.20.0
+     */
+    @Parameter(defaultValue = DEFAULT_TEMPLATES_URI_BASE, required = true, property = "quarkus.templatesUriBase")
+    String templatesUriBase;
+
+    /**
+     * Encoding to read and write files in the current source tree
+     *
+     * @since 0.20.0
+     */
+    @Parameter(defaultValue = DEFAULT_ENCODING, required = true, property = "quarkus.encoding")
+    String encoding;
+
+    /**
+     * Path relative to {@link #basedir} pointing at a {@code pom.xml} file containing the platform BOM (Bill of Materials) that
+     * manages extension artifacts. If set, the newly created runtime and deployment modules will be added to
+     * {@code <dependencyManagement>} section of this bom; otherwise the newly created modules will not be added
+     * to any BOM.
+     *
+     * @since 1.7.0.Final
+     */
+    @Parameter(property = "bomPath")
+    Path bomPath;
+
+    /**
+     * A version for the entries added to the platform BOM (see {@link #bomPath}).
+     * If you want to pass a property placeholder, use {@code @} instead if {@code $} so
+     * that the property is not evaluated by the current mojo - e.g. <code>@{my-project.version}</code>
+     *
+     * @since 0.25.0
+     */
+    @Parameter(property = "quarkus.bomEntryVersion", defaultValue = DEFAULT_BOM_ENTRY_VERSION)
+    String bomEntryVersion;
+
+    /**
+     * A list of strings of the form {@code groupId:artifactId:version[:type[:classifier[:scope]]]} representing the
+     * dependencies that should be added to the generated runtime module and to the platform BOM if it is specified via
+     * {@link #bomPath}.
+     * <p>
+     * In case the built-in Maven <code>${placeholder}</code> expansion does not work well for you (because you e.g.
+     * pass {@link #additionalRuntimeDependencies}) via CLI, the Mojo supports a custom <code>@{placeholder}</code>
+     * expansion:
+     * <ul>
+     * <li><code>@{$}</code> will be expanded to {@code $} - handy for escaping standard placeholders. E.g. to insert
+     * <code>${quarkus.version}</code> to the platform BOM, you need to pass <code>@{$}{quarkus.version}</code></li>
+     * <li><code>@{quarkus.field}</code> will be expanded to whatever value the given {@code field} of this mojo has at
+     * runtime.</li>
+     * <li>Any other <code>@{placeholder}</code> will be resolved using the current project's properties</li>
+     * </ul>
+     *
+     * @since 0.22.0
+     */
+    @Parameter(property = "quarkus.additionalRuntimeDependencies")
+    List<String> additionalRuntimeDependencies;
+
+    /**
+     * An absolute path or a path relative to {@link #basedir} pointing at a {@code pom.xml} file that should serve as
+     * a parent for the integration test Maven module this mojo generates. If {@link #itestParentPath} is not set,
+     * the integration test module will not be generated.
+     *
+     * @since 0.22.0
+     */
+    @Parameter(property = "quarkus.itestParentPath")
+    Path itestParentPath;
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    MavenProject project;
+
+    /**
+     * The entry point to Aether, i.e. the component doing all the work.
+     *
+     * @component
+     */
+    @Component
+    private RepositorySystem repoSystem;
+
+    /**
+     * The current repository/network configuration of Maven.
+     *
+     * @parameter default-value="${repositorySystemSession}"
+     * @readonly
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    /**
+     * The project's remote repositories to use for the resolution of artifacts and their dependencies.
+     *
+     * @parameter default-value="${project.remoteProjectRepositories}"
+     * @readonly
+     */
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    /**
+     * The version of {@code org.apache.maven.plugins:maven-compiler-plugin} that should be used for
+     * the extension project.
+     */
+    @Parameter(defaultValue = COMPILER_PLUGIN_DEFAULT_VERSION, required = true, property = "quarkus.mavenCompilerPluginVersion")
+    String compilerPluginVersion;
+
+    /**
+     * Indicates whether to generate a unit test class for the extension
+     *
+     * @since 1.10.0
+     */
+    @Parameter(property = "quarkus.generateUnitTest", defaultValue = "true")
+    boolean generateUnitTest;
+
+    /**
+     * Indicates whether to generate a dev mode unit test class for the extension
+     *
+     * @since 1.10.0
+     */
+    @Parameter(property = "quarkus.generateDevModeTest", defaultValue = "true")
+    boolean generateDevModeTest;
+
+    /**
+     * Indicates whether to generate the extension under the current directory or under a directory based on the
+     * artifactId
+     *
+     */
+    @Parameter(property = "quarkus.useCurrentDirectory", defaultValue = "false")
+    boolean useCurrentDirectory;
+
+    boolean currentProjectIsBaseDir;
+
+    Charset charset;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        if (this.basedir == null) {
+            currentProjectIsBaseDir = true;
+            this.basedir = new File(".").getAbsoluteFile();
+        }
+
+        if (deprecatedGroupId != null) {
+            if (groupId != null) {
+                throw new MojoExecutionException("Either groupId or deprecatedGroupId can be set at a time but got groupId="
+                        + groupId + " and deprecatedGroupId=" + deprecatedGroupId);
+            }
+            groupId = deprecatedGroupId;
+        }
+        if (deprecatedArtifactId != null) {
+            if (artifactId != null) {
+                throw new MojoExecutionException(
+                        "Either artifactId or deprecatedArtifactId can be set at a time but got artifactId=" + artifactId
+                                + " and deprecatedArtifactId=" + deprecatedArtifactId);
+            }
+            artifactId = deprecatedArtifactId;
+        }
+        if (deprecatedVersion != null) {
+            if (version != null) {
+                throw new MojoExecutionException("Either version or deprecatedVersion can be set at a time but got version="
+                        + version + " and deprecatedVersion=" + deprecatedVersion);
+            }
+            version = deprecatedVersion;
+        }
+        if (deprecatedQuarkusVersion != null) {
+            if (quarkusVersion != null && !DEFAULT_QUARKUS_VERSION.equals(quarkusVersion)) {
+                throw new MojoExecutionException(
+                        "Either quarkusVersion or deprecatedQuarkusVersion can be set at a time but got quarkusVersion="
+                                + quarkusVersion + " and deprecatedQuarkusVersion=" + deprecatedQuarkusVersion);
+            }
+            quarkusVersion = deprecatedQuarkusVersion;
+        }
+
+        if (artifactId != null) {
+            artifactIdBase = artifactIdBase(artifactId);
+            artifactIdPrefix = artifactId.substring(0, artifactId.length() - artifactIdBase.length());
+            artifactId = BRACKETS_PATTERN.matcher(artifactId).replaceAll("");
+        } else if (artifactIdBase != null) {
+            artifactId = artifactIdPrefix == null || artifactIdPrefix.isEmpty() ? artifactIdBase
+                    : artifactIdPrefix + artifactIdBase;
+        } else {
+            throw new MojoFailureException(String.format(
+                    "Either artifactId or both artifactIdPrefix and artifactIdBase must be specified; found: artifactId=[%s], artifactIdPrefix=[%s], artifactIdBase[%s]",
+                    artifactId, artifactIdPrefix, artifactIdBase));
+        }
+
+        if (name != null) {
+            final int pos = name.lastIndexOf(nameSegmentDelimiter);
+            if (pos >= 0) {
+                nameBase = name.substring(pos + nameSegmentDelimiter.length());
+            } else {
+                nameBase = name;
+            }
+            namePrefix = name.substring(0, name.length() - nameBase.length());
+        } else {
+            if (nameBase == null) {
+                nameBase = toCapWords(artifactIdBase);
+            }
+            if (namePrefix == null) {
+                namePrefix = "";
+            }
+            if (nameBase != null && namePrefix != null) {
+                name = namePrefix + nameBase;
+            } else {
+                throw new MojoFailureException("Either name or both namePrefix and nameBase must be specified");
+            }
+        }
+
+        if (bomPath != null) {
+            bomPath = basedir.toPath().resolve(bomPath);
+            if (!Files.exists(bomPath)) {
+                throw new MojoFailureException("bomPath does not exist: " + bomPath);
+            }
+        }
+
+        charset = Charset.forName(encoding);
+
+        try {
+            File rootPom = null;
+            Model rootModel = null;
+            boolean importDeploymentBom = true;
+            boolean setCompilerPluginVersion = true;
+            boolean setQuarkusVersionProp = true;
+            if (isCurrentProjectExists()) {
+                rootPom = getCurrentProjectPom();
+                if (rootPom != null && useCurrentDirectory) {
+                    throw new MojoFailureException(
+                            "Cannot add extension under this directory. Pom file was found.");
+                }
+                rootModel = MojoUtils.readPom(rootPom);
+                if (!"pom".equals(rootModel.getPackaging())) {
+                    throw new MojoFailureException(
+                            "Can add extension modules only under a project with packaging 'pom'; found: "
+                                    + rootModel.getPackaging() + "");
+                }
+
+                if (rootPom.equals(project.getFile())) {
+                    importDeploymentBom = !hasQuarkusDeploymentBom();
+                    setCompilerPluginVersion = !project.getPluginManagement().getPluginsAsMap()
+                            .containsKey(COMPILER_PLUGIN_KEY);
+                    setQuarkusVersionProp = !project.getProperties().containsKey(QUARKUS_VERSION_PROP);
+                } else {
+                    // aloubyansky: not sure we should support this case and not sure it ever worked properly
+                    // this is about creating an extension project not in the context of the current project from the Maven's plugin perspective
+                    // kind of a pathological use-case from the Maven's perspective, imo
+                    final DefaultArtifact rootArtifact = new DefaultArtifact(getGroupId(rootModel),
+                            rootModel.getArtifactId(), null, rootModel.getPackaging(), getVersion(rootModel));
+                    try {
+                        final MavenArtifactResolver mvn = MavenArtifactResolver.builder()
+                                .setRepositorySystem(repoSystem)
+                                .setRepositorySystemSession(repoSession)
+                                .setRemoteRepositories(repos)
+                                .setCurrentProject(LocalProject.loadWorkspace(rootPom.getParentFile().toPath()))
+                                .build();
+                        final ArtifactDescriptorResult rootDescr = mvn.resolveDescriptor(rootArtifact);
+                        importDeploymentBom = !hasQuarkusDeploymentBom(rootDescr.getManagedDependencies());
+                        // TODO determine whether the compiler plugin is configured for the project
+                        setQuarkusVersionProp = !rootDescr.getProperties().containsKey(QUARKUS_VERSION_PROP);
+                    } catch (Exception e) {
+                        throw new MojoExecutionException("Failed to resolve " + rootArtifact + " descriptor", e);
+                    }
+                }
+            } else if (parentRelativePath() != null) {
+                // aloubyansky: not sure we should support this case, same as above
+                final File gpPom = getExtensionProjectBaseDir().resolve(parentRelativePath()).normalize()
+                        .toAbsolutePath().toFile();
+                if (gpPom.exists()) {
+                    rootPom = gpPom;
+                    rootModel = MojoUtils.readPom(gpPom);
+                    final DefaultArtifact rootArtifact = new DefaultArtifact(getGroupId(rootModel),
+                            rootModel.getArtifactId(), null, rootModel.getPackaging(), getVersion(rootModel));
+                    try {
+                        final MavenArtifactResolver mvn = MavenArtifactResolver.builder()
+                                .setRepositorySystem(repoSystem)
+                                .setRepositorySystemSession(repoSession)
+                                .setRemoteRepositories(repos)
+                                .setCurrentProject(LocalProject.loadWorkspace(rootPom.getParentFile().toPath()))
+                                .build();
+                        final ArtifactDescriptorResult rootDescr = mvn.resolveDescriptor(rootArtifact);
+                        importDeploymentBom = !hasQuarkusDeploymentBom(rootDescr.getManagedDependencies());
+                        // TODO determine whether the compiler plugin is configured for the project
+                        setQuarkusVersionProp = !rootDescr.getProperties().containsKey(QUARKUS_VERSION_PROP);
+                    } catch (Exception e) {
+                        throw new MojoExecutionException("Failed to resolve " + rootArtifact + " descriptor", e);
+                    }
+                }
+            }
+
+            final TemplateParams templateParams = getTemplateParams(rootModel);
+            final Configuration cfg = getTemplateConfig();
+
+            generateExtensionProjects(cfg, templateParams);
+            if (setQuarkusVersionProp) {
+                setQuarkusVersionProp(getExtensionProjectBaseDir().resolve("pom.xml").toFile());
+            }
+            if (importDeploymentBom) {
+                addQuarkusDeploymentBom(getExtensionProjectBaseDir().resolve("pom.xml").toFile());
+            }
+            if (setCompilerPluginVersion) {
+                setCompilerPluginVersion(getExtensionProjectBaseDir().resolve("pom.xml").toFile());
+            }
+            if (rootModel != null) {
+                addModules(rootPom.toPath(), templateParams, rootModel);
+            }
+
+            if (bomPath != null) {
+                getLog().info(
+                        String.format("Adding [%s] to dependencyManagement in [%s]", templateParams.artifactId,
+                                bomPath));
+                List<PomTransformer.Transformation> transformations = new ArrayList<PomTransformer.Transformation>();
+                transformations
+                        .add(Transformation.addManagedDependency(templateParams.groupId, templateParams.artifactId,
+                                templateParams.bomEntryVersion));
+                for (Gavtcs gavtcs : templateParams.additionalRuntimeDependencies) {
+                    getLog().info(String.format("Adding [%s] to dependencyManagement in [%s]", gavtcs, bomPath));
+                    transformations.add(Transformation.addManagedDependency(gavtcs));
+                }
+                final String aId = templateParams.artifactId + "-deployment";
+                getLog().info(String.format("Adding [%s] to dependencyManagement in [%s]", aId, bomPath));
+                transformations.add(Transformation.addManagedDependency(templateParams.groupId, aId,
+                        templateParams.bomEntryVersion));
+
+                pomTransformer(bomPath).transform(transformations);
+            }
+            if (itestParentPath != null) {
+                generateItest(cfg, templateParams);
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException(String.format("Could not read %s", project.getFile()), e);
+        } catch (TemplateException e) {
+            throw new MojoExecutionException(String.format("Could not process a FreeMarker template"), e);
+        }
+    }
+
+    private void setQuarkusVersionProp(File pom) throws IOException, MojoExecutionException {
+        pomTransformer(pom.toPath()).transform(Transformation.addProperty(QUARKUS_VERSION_PROP,
+                quarkusVersion.equals(DEFAULT_QUARKUS_VERSION) ? getPluginVersion() : quarkusVersion));
+    }
+
+    private void setCompilerPluginVersion(File pom) throws IOException {
+        pomTransformer(pom.toPath()).transform(Transformation.addProperty(COMPILER_PLUGIN_VERSION_PROP, compilerPluginVersion));
+        pomTransformer(pom.toPath())
+                .transform(Transformation.addManagedPlugin(
+                        MojoUtils.plugin(COMPILER_PLUGIN_GROUP_ID, COMPILER_PLUGIN_ARTIFACT_ID,
+                                COMPILER_PLUGIN_VERSION_POM_EXPR)));
+    }
+
+    private void addQuarkusDeploymentBom(File pom) throws IOException, MojoExecutionException {
+        addQuarkusDeploymentBom(MojoUtils.readPom(pom), pom);
+    }
+
+    private void addQuarkusDeploymentBom(Model model, File file) throws IOException, MojoExecutionException {
+        pomTransformer(file.toPath())
+                .transform(Transformation.addManagedDependency(
+                        new Gavtcs(platformGroupId, platformArtifactId, QUARKUS_VERSION_POM_EXPR, "pom", null, "import")));
+    }
+
+    private String getPluginVersion() throws MojoExecutionException {
+        return CreateUtils.resolvePluginInfo(CreateExtensionLegacyMojo.class).getVersion();
+    }
+
+    private boolean hasQuarkusDeploymentBom() {
+        if (project.getDependencyManagement() == null) {
+            return false;
+        }
+        for (org.apache.maven.model.Dependency dep : project.getDependencyManagement().getDependencies()) {
+            if (dep.getArtifactId().equals("quarkus-core-deployment")
+                    && dep.getGroupId().equals("io.quarkus")) {
+                // this is not a 100% accurate check but practically valid
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasQuarkusDeploymentBom(List<Dependency> deps) {
+        if (deps == null) {
+            return false;
+        }
+        for (Dependency dep : deps) {
+            if (dep.getArtifact().getArtifactId().equals("quarkus-core-deployment")
+                    && dep.getArtifact().getGroupId().equals("io.quarkus")) {
+                // this is not a 100% accurate check but practically valid
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return true if the goal is executed in an existing project
+     */
+    private boolean isCurrentProjectExists() {
+        return currentProjectIsBaseDir ? project.getFile() != null
+                : Files.exists(basedir.toPath().resolve("pom.xml"));
+    }
+
+    private File getCurrentProjectPom() {
+        if (currentProjectIsBaseDir) {
+            return project.getFile() == null ? new File(project.getBasedir(), "pom.xml") : project.getFile();
+        }
+        return new File(basedir, "pom.xml");
+    }
+
+    private Path getExtensionProjectBaseDir() {
+        if (currentProjectIsBaseDir) {
+            if (useCurrentDirectory) {
+                return project.getBasedir() == null ? basedir.toPath()
+                        : project.getBasedir().toPath();
+            }
+            return project.getBasedir() == null ? basedir.toPath().resolve(artifactIdBase)
+                    : project.getBasedir().toPath().resolve(artifactIdBase);
+        }
+        return useCurrentDirectory ? basedir.toPath()
+                : new File(basedir, artifactIdBase).toPath();
+    }
+
+    private Path getExtensionRuntimeBaseDir() {
+        return getExtensionProjectBaseDir().resolve("runtime");
+    }
+
+    private Path getExtensionDeploymentBaseDir() {
+        return getExtensionProjectBaseDir().resolve("deployment");
+    }
+
+    void addModules(Path basePomXml, TemplateParams templateParams, Model basePom)
+            throws IOException, TemplateException, MojoFailureException, MojoExecutionException {
+        if (!basePom.getModules().contains(templateParams.artifactIdBase)) {
+            getLog().info(String.format("Adding module [%s] to [%s]", templateParams.artifactIdBase, basePomXml));
+            pomTransformer(basePomXml).transform(Transformation.addModule(templateParams.artifactIdBase));
+        }
+    }
+
+    private void generateExtensionProjects(Configuration cfg, TemplateParams templateParams)
+            throws IOException, TemplateException, MojoExecutionException {
+        evalTemplate(cfg, "parent-pom.xml", getExtensionProjectBaseDir().resolve("pom.xml"), templateParams);
+
+        Files.createDirectories(
+                getExtensionRuntimeBaseDir().resolve("src/main/java")
+                        .resolve(templateParams.javaPackageBase.replace('.', '/')));
+        evalTemplate(cfg, "runtime-pom.xml", getExtensionRuntimeBaseDir().resolve("pom.xml"),
+                templateParams);
+
+        evalTemplate(cfg, "deployment-pom.xml", getExtensionDeploymentBaseDir().resolve("pom.xml"),
+                templateParams);
+        final Path processorPath = getExtensionDeploymentBaseDir()
+                .resolve("src/main/java")
+                .resolve(templateParams.javaPackageBase.replace('.', '/'))
+                .resolve("deployment")
+                .resolve(templateParams.artifactIdBaseCamelCase + "Processor.java");
+        evalTemplate(cfg, "Processor.java", processorPath, templateParams);
+
+        if (generateUnitTest) {
+            generateUnitTestClass(cfg, templateParams);
+        }
+
+        if (generateDevModeTest) {
+            generateDevModeTestClass(cfg, templateParams);
+        }
+    }
+
+    private PomTransformer pomTransformer(Path basePomXml) {
+        return new PomTransformer(basePomXml, charset);
+    }
+
+    private TemplateParams getTemplateParams(Model basePom) throws MojoExecutionException {
+        final TemplateParams templateParams = new TemplateParams();
+
+        templateParams.artifactId = artifactId;
+        templateParams.artifactIdPrefix = artifactIdPrefix;
+        templateParams.artifactIdBase = artifactIdBase;
+        templateParams.artifactIdBaseCamelCase = toCapCamelCase(templateParams.artifactIdBase);
+
+        if (groupId == null) {
+            if (basePom == null) {
+                throw new MojoExecutionException(
+                        "Please provide the desired groupId for the project by setting groupId parameter");
+            }
+            templateParams.groupId = getGroupId(basePom);
+        } else {
+            templateParams.groupId = groupId;
+        }
+
+        if (version == null) {
+            if (basePom == null) {
+                throw new MojoExecutionException(
+                        "Please provide the desired version for the project by setting version parameter");
+            }
+            templateParams.version = getVersion(basePom);
+        } else {
+            templateParams.version = version;
+        }
+
+        templateParams.namePrefix = namePrefix;
+        templateParams.nameBase = nameBase;
+        templateParams.nameSegmentDelimiter = nameSegmentDelimiter;
+        templateParams.assumeManaged = detectAssumeManaged();
+        templateParams.quarkusVersion = QUARKUS_VERSION_POM_EXPR;
+        templateParams.bomEntryVersion = bomEntryVersion.replace('@', '$');
+
+        templateParams.grandParentGroupId = parentGroupId() != null ? parentGroupId() : getGroupId(basePom);
+        templateParams.grandParentArtifactId = parentArtifactId() != null ? parentArtifactId()
+                : basePom == null ? null : basePom.getArtifactId();
+        templateParams.grandParentVersion = parentVersion() != null ? parentVersion() : getVersion(basePom);
+        templateParams.grandParentRelativePath = parentRelativePath();
+
+        templateParams.javaPackageBase = javaPackageBase != null ? javaPackageBase
+                : getJavaPackage(templateParams.groupId, javaPackageInfix, artifactId);
+        templateParams.additionalRuntimeDependencies = getAdditionalRuntimeDependencies();
+        templateParams.bomPathSet = bomPath != null;
+        return templateParams;
+    }
+
+    private String parentArtifactId() {
+        return parentArtifactId == null ? grandParentArtifactId : parentArtifactId;
+    }
+
+    private String parentGroupId() {
+        return parentGroupId == null ? grandParentGroupId : parentGroupId;
+    }
+
+    private String parentVersion() {
+        return parentVersion == null ? grandParentVersion : parentVersion;
+    }
+
+    private String parentRelativePath() {
+        return parentRelativePath == null ? grandParentRelativePath : parentRelativePath;
+    }
+
+    private Configuration getTemplateConfig() throws IOException {
+        final Configuration templateCfg = new Configuration(Configuration.VERSION_2_3_28);
+        templateCfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+        templateCfg.setTemplateLoader(createTemplateLoader(basedir, templatesUriBase));
+        templateCfg.setDefaultEncoding(encoding);
+        templateCfg.setInterpolationSyntax(Configuration.SQUARE_BRACKET_INTERPOLATION_SYNTAX);
+        templateCfg.setTagSyntax(Configuration.SQUARE_BRACKET_TAG_SYNTAX);
+        return templateCfg;
+    }
+
+    private void generateUnitTestClass(Configuration cfg, TemplateParams model) throws IOException, TemplateException {
+        final Path unitTest = basedir.toPath()
+                .resolve(getExtensionTestPath(model.artifactIdBase) + model.javaPackageBase.replace('.', '/')
+                        + "/test/" + model.artifactIdBaseCamelCase + "Test.java");
+
+        evalTemplate(cfg, "UnitTest.java", unitTest, model);
+    }
+
+    private void generateDevModeTestClass(Configuration cfg, TemplateParams model) throws IOException, TemplateException {
+        final Path devModeTest = basedir
+                .toPath()
+                .resolve(getExtensionTestPath(model.artifactIdBase) + model.javaPackageBase.replace('.', '/')
+                        + "/test/" + model.artifactIdBaseCamelCase + "DevModeTest.java");
+
+        evalTemplate(cfg, "DevModeTest.java", devModeTest, model);
+
+    }
+
+    void generateItest(Configuration cfg, TemplateParams model)
+            throws MojoFailureException, MojoExecutionException, TemplateException, IOException {
+        final Path itestParentAbsPath = basedir.toPath().resolve(itestParentPath);
+        try (Reader r = Files.newBufferedReader(itestParentAbsPath, charset)) {
+            final Model itestParent = new MavenXpp3Reader().read(r);
+            if (!"pom".equals(itestParent.getPackaging())) {
+                throw new MojoFailureException(
+                        "Can add an extension integration test only under a project with packagin 'pom'; found: "
+                                + itestParent.getPackaging() + " in " + itestParentAbsPath);
+            }
+            model.itestParentGroupId = getGroupId(itestParent);
+            model.itestParentArtifactId = itestParent.getArtifactId();
+            model.itestParentVersion = getVersion(itestParent);
+            model.itestParentRelativePath = "../pom.xml";
+
+            final Path itestDir = itestParentAbsPath.getParent().resolve(model.artifactIdBase);
+            evalTemplate(cfg, "integration-test-pom.xml", itestDir.resolve("pom.xml"), model);
+            evalTemplate(cfg, "integration-test-application.properties",
+                    itestDir.resolve("src/main/resources/application.properties"), model);
+
+            final Path testResourcePath = itestDir.resolve("src/main/java/" + model.javaPackageBase.replace('.', '/')
+                    + "/it/" + model.artifactIdBaseCamelCase + "Resource.java");
+            evalTemplate(cfg, "TestResource.java", testResourcePath, model);
+            final Path testClassDir = itestDir
+                    .resolve("src/test/java/" + model.javaPackageBase.replace('.', '/') + "/it");
+            evalTemplate(cfg, "Test.java", testClassDir.resolve(model.artifactIdBaseCamelCase + "Test.java"),
+                    model);
+            evalTemplate(cfg, "IT.java", testClassDir.resolve(model.artifactIdBaseCamelCase + "IT.java"),
+                    model);
+
+            getLog().info(String.format("Adding module [%s] to [%s]", model.artifactIdBase, itestParentAbsPath));
+            pomTransformer(itestParentAbsPath).transform(Transformation.addModule(model.artifactIdBase));
+
+        } catch (IOException e) {
+            throw new MojoExecutionException(String.format("Could not read %s", itestParentAbsPath), e);
+        } catch (XmlPullParserException e) {
+            throw new MojoExecutionException(String.format("Could not parse %s", itestParentAbsPath), e);
+        }
+    }
+
+    private List<Gavtcs> getAdditionalRuntimeDependencies() {
+        final List<Gavtcs> result = new ArrayList<>();
+        if (additionalRuntimeDependencies != null && !additionalRuntimeDependencies.isEmpty()) {
+            for (String rawGavtc : additionalRuntimeDependencies) {
+                rawGavtc = replacePlaceholders(rawGavtc);
+                result.add(Gavtcs.of(rawGavtc));
+            }
+        }
+        return result;
+    }
+
+    private String replacePlaceholders(String gavtc) {
+        final StringBuffer transformedGavtc = new StringBuffer();
+        final Matcher m = PLACEHOLDER_PATTERN.matcher(gavtc);
+        while (m.find()) {
+            final String key = m.group(1);
+            if ("$".equals(key)) {
+                m.appendReplacement(transformedGavtc, QUOTED_DOLLAR);
+            } else if (key.startsWith("quarkus.")) {
+                final String fieldName = key.substring("quarkus.".length());
+                try {
+                    final Field field = this.getClass().getDeclaredField(fieldName);
+                    Object val = field.get(this);
+                    if (val != null) {
+                        m.appendReplacement(transformedGavtc, String.valueOf(val));
+                    }
+                } catch (NoSuchFieldException | SecurityException | IllegalArgumentException
+                        | IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                final Object val = project.getProperties().get(key);
+                if (val != null) {
+                    m.appendReplacement(transformedGavtc, String.valueOf(val));
+                }
+            }
+        }
+        m.appendTail(transformedGavtc);
+        return transformedGavtc.toString();
+    }
+
+    boolean detectAssumeManaged() {
+        return assumeManaged == null ? false : assumeManaged;
+    }
+
+    static String getGroupId(Model basePom) {
+        if (basePom == null) {
+            return null;
+        }
+        return basePom.getGroupId() != null ? basePom.getGroupId()
+                : basePom.getParent() != null && basePom.getParent().getGroupId() != null
+                        ? basePom.getParent().getGroupId()
+                        : null;
+    }
+
+    static String getVersion(Model basePom) {
+        if (basePom == null) {
+            return null;
+        }
+        return basePom.getVersion() != null ? basePom.getVersion()
+                : basePom.getParent() != null && basePom.getParent().getVersion() != null
+                        ? basePom.getParent().getVersion()
+                        : null;
+    }
+
+    static String toCapCamelCase(String artifactIdBase) {
+        final StringBuilder sb = new StringBuilder(artifactIdBase.length());
+        for (String segment : artifactIdBase.split("[.\\-]+")) {
+            sb.append(Character.toUpperCase(segment.charAt(0)));
+            if (segment.length() > 1) {
+                sb.append(segment.substring(1));
+            }
+        }
+        return sb.toString();
+    }
+
+    static String toCapWords(String artifactIdBase) {
+        final StringBuilder sb = new StringBuilder(artifactIdBase.length());
+        for (String segment : artifactIdBase.split("[.\\-]+")) {
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append(Character.toUpperCase(segment.charAt(0)));
+            if (segment.length() > 1) {
+                sb.append(segment.substring(1));
+            }
+        }
+        return sb.toString();
+    }
+
+    static String getJavaPackage(String groupId, String javaPackageInfix, String artifactId) {
+        final Stack<String> segments = new Stack<>();
+        for (String segment : groupId.split("[.\\-]+")) {
+            if (segments.isEmpty() || !segments.peek().equals(segment)) {
+                segments.add(segment);
+            }
+        }
+        if (javaPackageInfix != null) {
+            for (String segment : javaPackageInfix.split("[.\\-]+")) {
+                segments.add(segment);
+            }
+        }
+        for (String segment : artifactId.split("[.\\-]+")) {
+            if (!segments.contains(segment)) {
+                segments.add(segment);
+            }
+        }
+        return segments.stream() //
+                .map(s -> s.toLowerCase(Locale.ROOT)) //
+                .map(s -> SourceVersion.isKeyword(s) ? s + "_" : s) //
+                .collect(Collectors.joining("."));
+    }
+
+    static TemplateLoader createTemplateLoader(File basedir, String templatesUriBase) throws IOException {
+        final TemplateLoader defaultLoader = new ClassTemplateLoader(CreateExtensionLegacyMojo.class,
+                DEFAULT_TEMPLATES_URI_BASE.substring(CLASSPATH_PREFIX.length()));
+        if (DEFAULT_TEMPLATES_URI_BASE.equals(templatesUriBase)) {
+            return defaultLoader;
+        } else if (templatesUriBase.startsWith(CLASSPATH_PREFIX)) {
+            return new MultiTemplateLoader( //
+                    new TemplateLoader[] { //
+                            new ClassTemplateLoader(CreateExtensionLegacyMojo.class,
+                                    templatesUriBase.substring(CLASSPATH_PREFIX.length())), //
+                            defaultLoader //
+                    });
+        } else if (templatesUriBase.startsWith(FILE_PREFIX)) {
+            final Path resolvedTemplatesDir = basedir.toPath().resolve(templatesUriBase.substring(FILE_PREFIX.length()));
+            return new MultiTemplateLoader( //
+                    new TemplateLoader[] { //
+                            new FileTemplateLoader(resolvedTemplatesDir.toFile()),
+                            defaultLoader //
+                    });
+        } else {
+            throw new IllegalStateException(String.format(
+                    "Cannot handle templatesUriBase '%s'; only value starting with '%s' or '%s' are supported",
+                    templatesUriBase, CLASSPATH_PREFIX, FILE_PREFIX));
+        }
+    }
+
+    static void evalTemplate(Configuration cfg, String templateUri, Path dest, TemplateParams model)
+            throws IOException, TemplateException {
+        log.infof("Adding '%s'", dest);
+        final Template template = cfg.getTemplate(templateUri);
+        Files.createDirectories(dest.getParent());
+        try (Writer out = Files.newBufferedWriter(dest)) {
+            template.process(model, out);
+        }
+    }
+
+    static String artifactIdBase(String artifactId) {
+        final int lBPos = artifactId.indexOf('(');
+        final int rBPos = artifactId.indexOf(')');
+        if (lBPos >= 0 && rBPos >= 0) {
+            return artifactId.substring(lBPos + 1, rBPos);
+        } else {
+            return artifactId;
+        }
+    }
+
+    private String getExtensionTestPath(String artifactIdBase) {
+        return useCurrentDirectory ? "deployment/src/test/java/" : artifactIdBase + "/deployment/src/test/java/";
+    }
+
+    public void setItestParentPath(String itestParentPath) {
+        this.itestParentPath = Paths.get(itestParentPath);
+    }
+
+    public static class TemplateParams {
+        String grandParentRelativePath;
+        String grandParentVersion;
+        String grandParentArtifactId;
+        String grandParentGroupId;
+        String itestParentRelativePath;
+        String itestParentVersion;
+        String itestParentArtifactId;
+        String itestParentGroupId;
+        String groupId;
+        String artifactId;
+        String artifactIdPrefix;
+        String artifactIdBase;
+        String artifactIdBaseCamelCase;
+        String version;
+        String namePrefix;
+        String nameBase;
+        String nameSegmentDelimiter;
+        String javaPackageBase;
+        boolean assumeManaged;
+        String quarkusVersion;
+        List<Gavtcs> additionalRuntimeDependencies;
+        boolean bomPathSet;
+        String bomEntryVersion;
+
+        public String getJavaPackageBase() {
+            return javaPackageBase;
+        }
+
+        public boolean isAssumeManaged() {
+            return assumeManaged;
+        }
+
+        public String getArtifactIdPrefix() {
+            return artifactIdPrefix;
+        }
+
+        public String getArtifactIdBase() {
+            return artifactIdBase;
+        }
+
+        public String getNamePrefix() {
+            return namePrefix;
+        }
+
+        public String getNameBase() {
+            return nameBase;
+        }
+
+        public String getNameSegmentDelimiter() {
+            return nameSegmentDelimiter;
+        }
+
+        public String getArtifactIdBaseCamelCase() {
+            return artifactIdBaseCamelCase;
+        }
+
+        public String getQuarkusVersion() {
+            return quarkusVersion;
+        }
+
+        public String getGrandParentRelativePath() {
+            return grandParentRelativePath;
+        }
+
+        public String getGrandParentVersion() {
+            return grandParentVersion;
+        }
+
+        public String getGrandParentArtifactId() {
+            return grandParentArtifactId;
+        }
+
+        public String getGrandParentGroupId() {
+            return grandParentGroupId;
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getArtifactId() {
+            return artifactId;
+        }
+
+        public List<Gavtcs> getAdditionalRuntimeDependencies() {
+            return additionalRuntimeDependencies;
+        }
+
+        public boolean isBomPathSet() {
+            return bomPathSet;
+        }
+
+        public String getItestParentRelativePath() {
+            return itestParentRelativePath;
+        }
+
+        public String getItestParentVersion() {
+            return itestParentVersion;
+        }
+
+        public String getItestParentArtifactId() {
+            return itestParentArtifactId;
+        }
+
+        public String getItestParentGroupId() {
+            return itestParentGroupId;
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateExtensionMojo.java
@@ -1,0 +1,284 @@
+package io.quarkus.maven;
+
+import static io.quarkus.devtools.commands.CreateExtension.extractQuarkiverseExtensionId;
+import static io.quarkus.devtools.commands.CreateExtension.isQuarkiverseGroupId;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.fusesource.jansi.Ansi.ansi;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.jboss.logging.Logger;
+
+import io.quarkus.devtools.commands.CreateExtension;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.maven.components.Prompter;
+
+/**
+ * Creates the base of a
+ * <a href="https://quarkus.io/guides/writing-extensions">Quarkus Extension</a> in different layout depending of the options and
+ * environment.
+ * <br />
+ * <br />
+ * <h2>Create in the quarkus-parent project directory (or the extensions parent dir)</h2>
+ * <br />
+ * It will:
+ * <ul>
+ * <li>generate the new Quarkus extension in the extensions parent as a module (parent, runtime and deployment), with unit test
+ * and devmode test on option.</li>
+ * <li>On option, generate the new integration test in the integration tests parent as a module.</li>
+ * <li>add the dependencies to the bom/application/pom.xml.</li>
+ * </ul>
+ * <br />
+ * <h2>Creating a Quarkiverse extension</h2>
+ * <br />
+ * When using <code>-DgroupId=io.quarkiverse.[featureId]</code>, the new extension will use the Quarkiverse layout.
+ * <br />
+ * <br />
+ * <h2>Creating a standalone extension</h2>
+ * <br />
+ * <ul>
+ * <li>generate the new Quarkus extension in the current directory (parent, runtime and deployment), with unit test and devmode
+ * test on option.</li>
+ * <li>On option, generate the new integration test module in the current directory.</li>
+ * </ul>
+ */
+@Mojo(name = "create-extension", requiresProject = false)
+public class CreateExtensionMojo extends AbstractMojo {
+
+    private static final Logger log = Logger.getLogger(CreateExtensionMojo.class);
+
+    /**
+     * Directory where the changes should be performed.
+     * <br />
+     * <br />
+     * Default: the current directory of the current Java process.
+     */
+    @Parameter(property = "basedir")
+    File basedir;
+
+    /**
+     * {@code extensionId} of this extension (REQUIRED).
+     * <br />
+     * <br />
+     * It will be used to generate the different extension modules artifactIds
+     * (<code>[namespaceId][extensionId]-parent</code>), runtime (<code>[namespaceId][extensionId]</code>) and deployment
+     * (<code>[namespaceId][extensionId]-deployment</code>).
+     */
+    @Parameter(property = "extensionId")
+    String extensionId;
+
+    /**
+     * The {@code groupId} for the newly created Maven modules (REQUIRED - INHERITED IN QUARKUS-CORE).
+     */
+    @Parameter(property = "groupId")
+    String groupId;
+
+    /**
+     * Quarkus version the newly created extension should depend on (REQUIRED - INHERITED IN QUARKUS-CORE).
+     */
+    @Parameter(property = "quarkusVersion")
+    String quarkusVersion;
+
+    /**
+     * A prefix common to all extension artifactIds in the current source tree.
+     * <br />
+     * <br />
+     * Default: "quarkus-" in quarkus Quarkus Core and Quarkiverse else ""
+     */
+    @Parameter(property = "namespaceId")
+    String namespaceId;
+
+    /**
+     * The {@code version} for the newly created Maven modules.
+     * <br />
+     * <br />
+     * Default: automatic in Quarkus Core else {@link CreateExtension#DEFAULT_VERSION}
+     */
+    @Parameter(property = "version")
+    String version;
+
+    /**
+     * The {@code extensionName} of the runtime module. The {@code extensionName}s of the extension parent and deployment
+     * modules will be
+     * based on this {@code name} too.
+     * <br />
+     * <br />
+     * Default: the formatted {@code extensionId}
+     */
+    @Parameter(property = "extensionName")
+    String extensionName;
+
+    /**
+     * A prefix common to all extension names in the current source tree.
+     * <br />
+     * <br />
+     * Default: "quarkus-" in quarkus Quarkus Core and Quarkiverse else ""
+     */
+    @Parameter(property = "namespaceName")
+    String namespaceName;
+
+    /**
+     * Base package under which classes should be created in Runtime and Deployment modules.
+     * <br />
+     * <br />
+     * Default: auto-generated out of {@link #groupId}, {@link #namespaceId} and {@link #extensionId}
+     */
+    @Parameter(property = "packageName")
+    String packageName;
+
+    /**
+     * The {@code groupId} of the Quarkus platform BOM.
+     * <br />
+     * <br />
+     * Default: {@link CreateExtension#DEFAULT_BOM_GROUP_ID}
+     */
+    @Parameter(property = "quarkusBomGroupId")
+    String quarkusBomGroupId;
+
+    /**
+     * The {@code artifactId} of the Quarkus platform BOM.
+     * <br />
+     * <br />
+     * Default: {@link CreateExtension#DEFAULT_BOM_ARTIFACT_ID}
+     */
+    @Parameter(property = "quarkusBomArtifactId")
+    String quarkusBomArtifactId;
+
+    /**
+     * The {@code version} of the Quarkus platform BOM.
+     * <br />
+     * <br />
+     * Default: {@link CreateExtension#DEFAULT_BOM_VERSION}
+     */
+    @Parameter(property = "quarkusBomVersion")
+    String quarkusBomVersion;
+
+    /**
+     * Indicates whether to generate a unit test class for the extension
+     */
+    @Parameter(property = "withoutUnitTest")
+    boolean withoutUnitTest;
+
+    /**
+     * Indicates whether to generate an integration tests for the extension
+     */
+    @Parameter(property = "withoutIntegrationTests")
+    boolean withoutIntegrationTests;
+
+    /**
+     * Indicates whether to generate a devmode test for the extension
+     */
+    @Parameter(property = "withoutDevModeTest")
+    boolean withoutDevModeTest;
+
+    /**
+     * Indicates whether to generate any tests for the extension (same as
+     * <code>-DwithoutUnitTest -DwithoutIntegrationTest -DwithoutDevModeTest</code>)
+     */
+    @Parameter(property = "withoutTests")
+    boolean withoutTests;
+
+    /**
+     * Used to detect legacy command usage and display an error
+     */
+    @Parameter(property = "artifactId")
+    String artifactId;
+
+    @Parameter(defaultValue = "${project}")
+    protected MavenProject project;
+
+    @Parameter(defaultValue = "${session}")
+    private MavenSession session;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+
+        if (!isBlank(artifactId)) {
+            if (isBlank(extensionId)) {
+                getLog().warn(ansi().a(
+                        "the given 'artifactId' has been automatically converted to 'extensionId' for backward compatibility.")
+                        .toString());
+                if (artifactId.startsWith("quarkus-")) {
+                    namespaceId = "quarkus-";
+                    extensionId = artifactId.replace("quarkus-", "");
+                } else {
+                    extensionId = artifactId;
+                }
+            }
+        }
+
+        promptValues();
+
+        autoComputeQuarkiverseExtensionId();
+
+        final CreateExtension createExtension = new CreateExtension(basedir.toPath())
+                .extensionId(extensionId)
+                .extensionName(extensionName)
+                .groupId(groupId)
+                .version(version)
+                .packageName(packageName)
+                .namespaceId(namespaceId)
+                .namespaceName(namespaceName)
+                .quarkusVersion(quarkusVersion)
+                .quarkusBomGroupId(quarkusBomGroupId)
+                .quarkusBomArtifactId(quarkusBomArtifactId)
+                .quarkusBomGroupId(quarkusBomVersion)
+                .withoutUnitTest(withoutTests || withoutUnitTest)
+                .withoutDevModeTest(withoutTests || withoutDevModeTest)
+                .withoutIntegrationTests(withoutTests || withoutIntegrationTests);
+
+        boolean success;
+
+        try {
+            success = createExtension.execute().isSuccess();
+        } catch (QuarkusCommandException e) {
+            throw new MojoExecutionException("Failed to generate Extension", e);
+        }
+
+        if (!success) {
+            throw new MojoExecutionException("Failed to generate Extension");
+        }
+    }
+
+    private void autoComputeQuarkiverseExtensionId() {
+        if (isQuarkiverseGroupId(groupId) && isEmpty(extensionId)) {
+            extensionId = extractQuarkiverseExtensionId(groupId);
+        }
+    }
+
+    private String getPluginVersion() throws MojoExecutionException {
+        return CreateUtils.resolvePluginInfo(CreateExtensionLegacyMojo.class).getVersion();
+    }
+
+    private void promptValues() throws MojoExecutionException {
+        if (!session.getRequest().isInteractiveMode()) {
+            return;
+        }
+        try {
+            final Prompter prompter = new Prompter();
+            if (project == null || !project.getArtifactId().endsWith("quarkus-parent")) {
+                if (isBlank(quarkusVersion)) {
+                    quarkusVersion = getPluginVersion();
+                }
+                if (isBlank(groupId)) {
+                    prompter.addPrompt("Set the extension groupId: ", "org.acme", input -> groupId = input);
+                }
+            }
+            autoComputeQuarkiverseExtensionId();
+            if (isBlank(extensionId)) {
+                prompter.addPrompt("Set the extension id: ", input -> extensionId = input);
+            }
+            prompter.collectInput();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Unable to get user input", e);
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateJBangMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateJBangMojo.java
@@ -1,0 +1,139 @@
+package io.quarkus.maven;
+
+import static io.quarkus.devtools.project.CodestartResourceLoadersBuilder.codestartLoadersBuilder;
+import static org.fusesource.jansi.Ansi.ansi;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.devtools.commands.CreateJBangProject;
+import io.quarkus.devtools.commands.data.QuarkusCommandException;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.maven.utilities.MojoUtils;
+import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
+import io.quarkus.platform.tools.maven.MojoMessageWriter;
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+
+@Mojo(name = "create-jbang", requiresProject = false)
+public class CreateJBangMojo extends AbstractMojo {
+
+    @Parameter(property = "noJBangWrapper", defaultValue = "false")
+    private boolean noJBangWrapper;
+
+    /**
+     * Group ID of the target platform BOM
+     */
+    @Parameter(property = "platformGroupId", required = false)
+    private String bomGroupId;
+
+    /**
+     * Artifact ID of the target platform BOM
+     */
+    @Parameter(property = "platformArtifactId", required = false)
+    private String bomArtifactId;
+
+    /**
+     * Version of the target platform BOM
+     */
+    @Parameter(property = "platformVersion", required = false)
+    private String bomVersion;
+
+    @Parameter(property = "extensions")
+    private Set<String> extensions;
+
+    @Parameter(property = "outputDirectory", defaultValue = "${basedir}/jbang-with-quarkus")
+    private File outputDirectory;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Component
+    RemoteRepositoryManager remoteRepoManager;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        try {
+            Files.createDirectories(outputDirectory.toPath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Could not create directory " + outputDirectory, e);
+        }
+
+        File projectRoot = outputDirectory;
+        final Path projectDirPath = projectRoot.toPath();
+
+        final MavenArtifactResolver mvn;
+        try {
+            mvn = MavenArtifactResolver.builder()
+                    .setRepositorySystem(repoSystem)
+                    .setRepositorySystemSession(
+                            getLog().isDebugEnabled() ? repoSession : MojoUtils.muteTransferListener(repoSession))
+                    .setRemoteRepositories(repos)
+                    .setRemoteRepositoryManager(remoteRepoManager)
+                    .build();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
+        }
+
+        final MessageWriter log = new MojoMessageWriter(getLog());
+        ExtensionCatalog catalog;
+        try {
+            catalog = CreateProjectMojo.resolveExtensionsCatalog(this, bomGroupId, bomArtifactId, bomVersion,
+                    QuarkusProjectHelper.getCatalogResolver(mvn, log), mvn, log);
+        } catch (RegistryResolutionException e) {
+            throw new MojoExecutionException("Failed to resolve Quarkus extension catalog", e);
+        }
+
+        final List<ResourceLoader> codestartsResourceLoader = codestartLoadersBuilder()
+                .catalog(catalog)
+                .artifactResolver(mvn)
+                .build();
+        final CreateJBangProject createJBangProject = new CreateJBangProject(QuarkusProject.of(projectDirPath, catalog,
+                codestartsResourceLoader, log, BuildTool.MAVEN))
+                        .extensions(extensions)
+                        .setValue("noJBangWrapper", noJBangWrapper);
+
+        boolean success;
+
+        try {
+            success = createJBangProject.execute().isSuccess();
+        } catch (QuarkusCommandException e) {
+            throw new MojoExecutionException("Failed to generate JBang Quarkus project", e);
+        }
+
+        if (success) {
+            getLog().info("");
+            getLog().info("========================================================================");
+            getLog().warn(ansi().a("Quarkus JBang project is an experimental feature.").toString());
+            getLog().info("========================================================================");
+            getLog().info("");
+        } else {
+            throw new MojoExecutionException(
+                    "Failed to generate JBang Quarkus project");
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateProjectMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateProjectMojo.java
@@ -1,0 +1,505 @@
+package io.quarkus.maven;
+
+import static io.quarkus.devtools.project.CodestartResourceLoadersBuilder.codestartLoadersBuilder;
+import static org.fusesource.jansi.Ansi.ansi;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.fusesource.jansi.Ansi;
+
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.devtools.commands.CreateProject;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.devtools.project.codegen.CreateProjectHelper;
+import io.quarkus.devtools.project.codegen.SourceType;
+import io.quarkus.maven.components.MavenVersionEnforcer;
+import io.quarkus.maven.components.Prompter;
+import io.quarkus.maven.utilities.MojoUtils;
+import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
+import io.quarkus.platform.tools.ToolsUtils;
+import io.quarkus.platform.tools.maven.MojoMessageWriter;
+import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.config.RegistriesConfigLocator;
+import io.quarkus.registry.config.RegistryConfig;
+
+/**
+ * This goal helps in setting up Quarkus Maven project with quarkus-maven-plugin, with sensible defaults
+ */
+@Mojo(name = "create", requiresProject = false)
+public class CreateProjectMojo extends AbstractMojo {
+
+    private static final String DEFAULT_GROUP_ID = "org.acme";
+    private static final String DEFAULT_ARTIFACT_ID = "code-with-quarkus";
+    private static final String DEFAULT_VERSION = "1.0.0-SNAPSHOT";
+    private static final String DEFAULT_EXTENSIONS = "resteasy";
+
+    @Parameter(defaultValue = "${project}")
+    protected MavenProject project;
+
+    @Parameter(property = "projectGroupId")
+    private String projectGroupId;
+
+    @Parameter(property = "projectArtifactId")
+    private String projectArtifactId;
+
+    @Parameter(property = "projectVersion")
+    private String projectVersion;
+
+    /**
+     * When true, do not include any code in the generated Quarkus project.
+     */
+    @Parameter(property = "noCode", defaultValue = "false")
+    private boolean noCode;
+
+    @Parameter(property = "example")
+    private String example;
+
+    /**
+     * Group ID of the target platform BOM
+     */
+    @Parameter(property = "platformGroupId", required = false)
+    private String bomGroupId;
+
+    /**
+     * Artifact ID of the target platform BOM
+     */
+    @Parameter(property = "platformArtifactId", required = false)
+    private String bomArtifactId;
+
+    /**
+     * Version of the target platform BOM
+     */
+    @Parameter(property = "platformVersion", required = false)
+    private String bomVersion;
+
+    /**
+     * The {@link #path} will define the REST path of the generated code when picking only one of those extensions resteasy,
+     * resteasy-reactive and spring-web.
+     * <br />
+     * If more than one of those extensions are picked, this parameter will be ignored.
+     * <br />
+     * This is @Deprecated because using a generic path parameters with multiple example does not make sense and lead to
+     * confusion.
+     * More info: https://github.com/quarkusio/quarkus/issues/14437
+     * <br />
+     * {@code className}
+     */
+    @Parameter(property = "path")
+    @Deprecated
+    private String path;
+
+    /**
+     * The {@link #className} will define the generated class names when picking only one of those extensions resteasy,
+     * resteasy-reactive and spring-web.
+     * <br />
+     * If more than one of those extensions are picked, then only the package name part will be used as {@link #packageName}
+     * <br />
+     * This is @Deprecated because using a generic className parameters with multiple example does not make sense and lead to
+     * confusion.
+     * More info: https://github.com/quarkusio/quarkus/issues/14437
+     * <br />
+     * By default, the {@link #projectGroupId} is used as package for generated classes (you can also use {@link #packageName}
+     * to have them different).
+     * <br />
+     * {@code className}
+     */
+    @Parameter(property = "className")
+    @Deprecated
+    private String className;
+
+    /**
+     * Set the package name of the generated classes.
+     * <br />
+     * If not set, {@link #projectGroupId} will be used as {@link #packageName}
+     * <p>
+     * {@code packageName}
+     */
+    @Parameter(property = "packageName")
+    private String packageName;
+
+    @Parameter(property = "buildTool", defaultValue = "MAVEN")
+    private String buildTool;
+
+    @Parameter(property = "extensions")
+    private Set<String> extensions;
+
+    @Parameter(property = "outputDirectory", defaultValue = "${basedir}")
+    private File outputDirectory;
+
+    @Parameter(defaultValue = "${session}")
+    private MavenSession session;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    @Component
+    private MavenVersionEnforcer mavenVersionEnforcer;
+
+    @Component
+    private BuildPluginManager pluginManager;
+
+    @Component
+    private ProjectBuilder projectBuilder;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Component
+    RemoteRepositoryManager remoteRepoManager;
+
+    @Parameter(property = "appConfig")
+    private String appConfig;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+
+        // We detect the Maven version during the project generation to indicate the user immediately that the installed
+        // version may not be supported.
+        mavenVersionEnforcer.ensureMavenVersion(getLog(), session);
+        try {
+            Files.createDirectories(outputDirectory.toPath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Could not create directory " + outputDirectory, e);
+        }
+
+        final MavenArtifactResolver mvn;
+        try {
+            mvn = MavenArtifactResolver.builder()
+                    .setRepositorySystem(repoSystem)
+                    .setRepositorySystemSession(
+                            getLog().isDebugEnabled() ? repoSession : MojoUtils.muteTransferListener(repoSession))
+                    .setRemoteRepositories(repos)
+                    .setRemoteRepositoryManager(remoteRepoManager)
+                    .build();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
+        }
+        final MojoMessageWriter log = new MojoMessageWriter(getLog());
+        ExtensionCatalogResolver catalogResolver;
+        try {
+            catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                    ? QuarkusProjectHelper.getCatalogResolver(mvn, log)
+                    : ExtensionCatalogResolver.empty();
+        } catch (RegistryResolutionException e) {
+            // fall back to the default platform
+            catalogResolver = ExtensionCatalogResolver.empty();
+        }
+
+        final ExtensionCatalog catalog = resolveExtensionsCatalog(this, bomGroupId, bomArtifactId, bomVersion, catalogResolver,
+                mvn, log);
+
+        File projectRoot = outputDirectory;
+        File pom = project != null ? project.getFile() : null;
+        Model parentPomModel = null;
+
+        boolean containsAtLeastOneGradleFile = false;
+        for (String gradleFile : Arrays.asList("build.gradle", "settings.gradle", "build.gradle.kts", "settings.gradle.kts")) {
+            containsAtLeastOneGradleFile |= new File(projectRoot, gradleFile).isFile();
+        }
+
+        BuildTool buildToolEnum = BuildTool.findTool(buildTool);
+        if (buildToolEnum == null) {
+            String validBuildTools = String.join(",",
+                    Arrays.asList(BuildTool.values()).stream().map(BuildTool::toString).collect(Collectors.toList()));
+            throw new IllegalArgumentException("Choose a valid build tool. Accepted values are: " + validBuildTools);
+        }
+        if (BuildTool.MAVEN.equals(buildToolEnum)) {
+            if (pom != null && pom.isFile()) {
+                try {
+                    parentPomModel = MojoUtils.readPom(pom);
+                    if (!"pom".equals(parentPomModel.getPackaging())) {
+                        throw new MojoExecutionException(
+                                "The parent project must have a packaging type of POM. Current packaging: "
+                                        + parentPomModel.getPackaging());
+                    }
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Could not access parent pom.", e);
+                }
+            } else if (containsAtLeastOneGradleFile) {
+                throw new MojoExecutionException(
+                        "You are trying to create a Maven project in a directory that contains only Gradle build files.");
+            }
+        } else if (BuildTool.GRADLE.equals(buildToolEnum) || BuildTool.GRADLE_KOTLIN_DSL.equals(buildToolEnum)) {
+            if (containsAtLeastOneGradleFile) {
+                throw new MojoExecutionException("Adding subprojects to gradle projects is not implemented.");
+            } else if (pom != null && pom.isFile()) {
+                throw new MojoExecutionException(
+                        "You are trying to create gradle project in a directory that contains only maven build files.");
+            }
+        }
+
+        askTheUserForMissingValues();
+        projectRoot = new File(outputDirectory, projectArtifactId);
+        if (projectRoot.exists()) {
+            throw new MojoExecutionException("Unable to create the project, " +
+                    "the directory " + projectRoot.getAbsolutePath() + " already exists");
+        }
+
+        boolean success;
+        final Path projectDirPath = projectRoot.toPath();
+        try {
+            extensions = CreateProjectHelper.sanitizeExtensions(extensions);
+            final SourceType sourceType = CreateProjectHelper.determineSourceType(extensions);
+            sanitizeOptions(sourceType);
+
+            final List<ResourceLoader> codestartsResourceLoader = codestartLoadersBuilder()
+                    .catalog(catalog)
+                    .artifactResolver(mvn)
+                    .build();
+            QuarkusProject newProject = QuarkusProject.of(projectDirPath, catalog,
+                    codestartsResourceLoader, log, buildToolEnum);
+            final CreateProject createProject = new CreateProject(newProject)
+                    .groupId(projectGroupId)
+                    .artifactId(projectArtifactId)
+                    .version(projectVersion)
+                    .sourceType(sourceType)
+                    .className(className)
+                    .packageName(packageName)
+                    .extensions(extensions)
+                    .example(example)
+                    .noCode(noCode)
+                    .appConfig(appConfig);
+            if (path != null) {
+                createProject.setValue("path", path);
+            }
+
+            success = createProject.execute().isSuccess();
+            if (success && parentPomModel != null && BuildTool.MAVEN.equals(buildToolEnum)) {
+                // Write to parent pom and submodule pom if project creation is successful
+                if (!parentPomModel.getModules().contains(this.projectArtifactId)) {
+                    parentPomModel.addModule(this.projectArtifactId);
+                }
+                File subModulePomFile = new File(projectRoot, buildToolEnum.getDependenciesFile());
+                Model subModulePomModel = MojoUtils.readPom(subModulePomFile);
+                Parent parent = new Parent();
+                parent.setGroupId(parentPomModel.getGroupId());
+                parent.setArtifactId(parentPomModel.getArtifactId());
+                parent.setVersion(parentPomModel.getVersion());
+                subModulePomModel.setParent(parent);
+                MojoUtils.write(parentPomModel, pom);
+                MojoUtils.write(subModulePomModel, subModulePomFile);
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to generate Quarkus project", e);
+        }
+        if (success) {
+            printUserInstructions(projectRoot);
+        } else {
+            throw new MojoExecutionException(
+                    "The project was created but (some of) the requested extensions couldn't be added.");
+        }
+    }
+
+    static ExtensionCatalog resolveExtensionsCatalog(AbstractMojo mojo, String groupId, String artifactId, String version,
+            ExtensionCatalogResolver catalogResolver, MavenArtifactResolver artifactResolver, MessageWriter log)
+            throws MojoExecutionException {
+
+        if (catalogResolver.hasRegistries()) {
+            try {
+                return isBlank(groupId) && isBlank(artifactId) && isBlank(version)
+                        ? catalogResolver.resolveExtensionCatalog()
+                        : catalogResolver.resolveExtensionCatalog(Collections.singletonList(
+                                new ArtifactCoords(getPlatformGroupId(mojo, groupId), getPlatformArtifactId(artifactId), "pom",
+                                        getPlatformVersion(mojo, version))));
+            } catch (RegistryResolutionException e) {
+                final StringBuilder buf = new StringBuilder();
+                buf.append("Failed to resolve the extension catalog");
+                Throwable cause = e.getCause();
+                while (cause != null) {
+                    buf.append(": ").append(cause.getLocalizedMessage());
+                    cause = cause.getCause();
+                }
+                log.warn(buf.toString());
+            }
+        }
+        return resolveExtensionCatalogDirectly(mojo, groupId, artifactId, version, catalogResolver, artifactResolver, log);
+    }
+
+    private static ExtensionCatalog resolveExtensionCatalogDirectly(AbstractMojo mojo, String groupId, String artifactId,
+            String version,
+            ExtensionCatalogResolver catalogResolver, MavenArtifactResolver artifactResolver, MessageWriter log) {
+        groupId = getPlatformGroupId(mojo, groupId);
+        artifactId = getPlatformArtifactId(artifactId);
+        version = getPlatformVersion(mojo, version);
+        final StringBuilder buf = new StringBuilder();
+        buf.append("The extension catalog will be narrowed to the ").append(groupId).append(":").append(artifactId)
+                .append(":").append(version).append(" platform release.");
+        buf.append(
+                " To enable the complete Quarkiverse extension catalog along with the latest recommended platform releases, please, make sure ");
+        if (QuarkusProjectHelper.isRegistryClientEnabled()) {
+            buf.append("the following registries are accessible from your environment: ");
+            final Iterator<RegistryConfig> iterator = RegistriesConfigLocator.resolveConfig().getRegistries().iterator();
+            int i = 0;
+            while (iterator.hasNext()) {
+                final RegistryConfig r = iterator.next();
+                if (r.isEnabled()) {
+                    if (i++ > 0) {
+                        buf.append(", ");
+                    }
+                    buf.append(r.getId());
+                }
+            }
+        } else {
+            buf.append("the extension registry client is enabled.");
+        }
+        log.warn(buf.toString());
+        return ToolsUtils.resolvePlatformDescriptorDirectly(groupId, artifactId, version, artifactResolver, log);
+    }
+
+    private void askTheUserForMissingValues() throws MojoExecutionException {
+
+        // If the user has disabled the interactive mode or if the user has specified the artifactId, disable the
+        // user interactions.
+        if (!session.getRequest().isInteractiveMode() || shouldUseDefaults()) {
+            if (isBlank(projectArtifactId)) {
+                // we need to set it for the project directory
+                projectArtifactId = DEFAULT_ARTIFACT_ID;
+            }
+            if (isBlank(projectGroupId)) {
+                projectGroupId = DEFAULT_GROUP_ID;
+            }
+            if (isBlank(projectVersion)) {
+                projectVersion = DEFAULT_VERSION;
+            }
+            return;
+        }
+
+        try {
+            final Prompter prompter = new Prompter();
+            if (isBlank(projectGroupId)) {
+                prompter.addPrompt("Set the project groupId: ", DEFAULT_GROUP_ID, input -> projectGroupId = input);
+            }
+
+            if (isBlank(projectArtifactId)) {
+                prompter.addPrompt("Set the project artifactId: ", DEFAULT_ARTIFACT_ID, input -> projectArtifactId = input);
+            }
+
+            if (isBlank(projectVersion)) {
+                prompter.addPrompt("Set the project version: ", DEFAULT_VERSION, input -> projectVersion = input);
+            }
+
+            if (!noCode && isBlank(example)) {
+                if (extensions.isEmpty()) {
+                    prompter.addPrompt("What extensions do you wish to add (comma separated list): ", DEFAULT_EXTENSIONS,
+                            input -> extensions = Arrays
+                                    .stream(input.split(","))
+                                    .map(String::trim).filter(Predicate.not(String::isEmpty)).collect(Collectors.toSet()));
+                }
+                prompter.addPrompt("Would you like some code to start (yes), or just an empty Quarkus project (no): ", "yes",
+                        input -> noCode = input.startsWith("n"));
+
+                prompter.collectInput();
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Unable to get user input", e);
+        }
+    }
+
+    private boolean shouldUseDefaults() {
+        // Must be called before user input
+        return projectArtifactId != null;
+
+    }
+
+    private void sanitizeOptions(SourceType sourceType) {
+        if (className != null) {
+            className = sourceType.stripExtensionFrom(className);
+
+            int idx = className.lastIndexOf('.');
+            if (idx >= 0 && isBlank(packageName)) {
+                // if it's a full qualified class name, we use the package name part (only if the packageName wasn't already defined)
+                packageName = className.substring(0, idx);
+
+                // And we strip it from the className
+                className = className.substring(idx + 1);
+            }
+
+            if (isBlank(path)) {
+                path = "/hello";
+            } else if (!path.startsWith("/")) {
+                path = "/" + path;
+            }
+        }
+        // if package name is empty, the groupId will be used as part of the CreateProject logic
+    }
+
+    private void printUserInstructions(File root) {
+        getLog().info("");
+        getLog().info("========================================================================================");
+        getLog().info(
+                ansi().a("Your new application has been created in ").bold().a(root.getAbsolutePath()).boldOff().toString());
+        getLog().info(ansi().a("Navigate into this directory and launch your application with ")
+                .bold()
+                .fg(Ansi.Color.CYAN)
+                .a("mvn quarkus:dev")
+                .reset()
+                .toString());
+        getLog().info(
+                ansi().a("Your application will be accessible on ").bold().fg(Ansi.Color.CYAN).a("http://localhost:8080")
+                        .reset().toString());
+        getLog().info("========================================================================================");
+        getLog().info("");
+    }
+
+    public static String getPlatformVersion(AbstractMojo mojo, String version) {
+        return isBlank(version) ? getPluginVersion(mojo) : version;
+    }
+
+    public static String getPlatformArtifactId(String artifactId) {
+        return isBlank(artifactId) ? "quarkus-bom" : artifactId;
+    }
+
+    public static String getPlatformGroupId(AbstractMojo mojo, String groupId) {
+        return isBlank(groupId) ? getPluginGroupId(mojo) : groupId;
+    }
+
+    private static String getPluginGroupId(AbstractMojo mojo) {
+        return getPluginDescriptor(mojo).getGroupId();
+    }
+
+    private static String getPluginVersion(AbstractMojo mojo) {
+        return getPluginDescriptor(mojo).getVersion();
+    }
+
+    private static PluginDescriptor getPluginDescriptor(AbstractMojo mojo) {
+        return (PluginDescriptor) mojo.getPluginContext().get("pluginDescriptor");
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateUtils.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/CreateUtils.java
@@ -1,0 +1,117 @@
+package io.quarkus.maven;
+
+import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import io.quarkus.bootstrap.util.ZipUtils;
+import io.quarkus.maven.utilities.MojoUtils;
+
+public final class CreateUtils {
+
+    public static final String GRADLE_WRAPPER_PATH = "gradle-wrapper";
+    public static final String[] GRADLE_WRAPPER_FILES = new String[] {
+            "gradlew",
+            "gradlew.bat",
+            "gradle/wrapper/gradle-wrapper.properties",
+            "gradle/wrapper/gradle-wrapper.jar"
+    };
+
+    private CreateUtils() {
+        //Not to be constructed
+    }
+
+    public static String getDerivedPath(String className) {
+        String[] resourceClassName = StringUtils.splitByCharacterTypeCamelCase(
+                className.substring(className.lastIndexOf(".") + 1));
+        return "/" + resourceClassName[0].toLowerCase();
+    }
+
+    public static Plugin resolvePluginInfo(Class<?> cls) throws MojoExecutionException {
+        try {
+            final Path classOrigin = MojoUtils.getClassOrigin(cls);
+            if (Files.isDirectory(classOrigin)) {
+                return resolvePluginInfo(classOrigin.resolve("META-INF").resolve("maven").resolve("plugin.xml"));
+            }
+            try (FileSystem fs = ZipUtils.newFileSystem(classOrigin)) {
+                return resolvePluginInfo(fs.getPath("META-INF", "maven", "plugin.xml"));
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to resolve maven plugin version containing " + cls, e);
+        }
+    }
+
+    private static Plugin resolvePluginInfo(Path pluginXml) throws MojoExecutionException {
+        if (!Files.exists(pluginXml)) {
+            throw new MojoExecutionException("Failed to locate " + pluginXml);
+        }
+        final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        try {
+            final DocumentBuilder db = dbf.newDocumentBuilder();
+            try (InputStream is = Files.newInputStream(pluginXml)) {
+                final Document doc = db.parse(is);
+                final Node pluginNode = getElement(doc.getChildNodes(), "plugin");
+                final Plugin plugin = new Plugin();
+                plugin.setGroupId(getChildElementTextValue(pluginNode, "groupId"));
+                plugin.setArtifactId(getChildElementTextValue(pluginNode, "artifactId"));
+                plugin.setVersion(getChildElementTextValue(pluginNode, "version"));
+                return plugin;
+            }
+        } catch (Throwable t) {
+            throw new MojoExecutionException("Failed to parse " + pluginXml, t);
+        }
+    }
+
+    private static String getChildElementTextValue(final Node parentNode, String childName) throws MojoExecutionException {
+        final Node node = getElement(parentNode.getChildNodes(), childName);
+        final String text = getText(node);
+        if (text.isEmpty()) {
+            throw new MojoExecutionException(
+                    "The " + parentNode.getNodeName() + " element description is missing child " + childName);
+        }
+        return text;
+    }
+
+    private static Node getElement(NodeList nodeList, String name) throws MojoExecutionException {
+        for (int i = 0; i < nodeList.getLength(); ++i) {
+            final Node item = nodeList.item(i);
+            if (item.getNodeType() == Node.ELEMENT_NODE
+                    && (name.equals(item.getNodeName()) || name.equals(item.getLocalName()))) {
+                return item;
+            }
+        }
+        throw new MojoExecutionException("Failed to locate element " + name);
+    }
+
+    private static String getText(Node node) {
+        if (!node.hasChildNodes()) {
+            return "";
+        }
+        StringBuffer result = new StringBuffer();
+        NodeList list = node.getChildNodes();
+        for (int i = 0; i < list.getLength(); i++) {
+            Node subnode = list.item(i);
+            if (subnode.getNodeType() == Node.TEXT_NODE) {
+                result.append(subnode.getNodeValue());
+            } else if (subnode.getNodeType() == Node.CDATA_SECTION_NODE) {
+                result.append(subnode.getNodeValue());
+            } else if (subnode.getNodeType() == Node.ENTITY_REFERENCE_NODE) {
+                // Recurse into the subtree for text
+                // (and ignore comments)
+                result.append(getText(subnode));
+            }
+        }
+        return result.toString();
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/DependencyTreeMojo.java
@@ -1,0 +1,143 @@
+package io.quarkus.maven;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.maven.dependency.GACTV;
+
+/**
+ * Displays Quarkus application build dependency tree including the deployment ones.
+ */
+@Mojo(name = "dependency-tree", defaultPhase = LifecyclePhase.NONE, requiresDependencyResolution = ResolutionScope.NONE)
+public class DependencyTreeMojo extends AbstractMojo {
+
+    @Component
+    protected QuarkusBootstrapProvider bootstrapProvider;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    protected MavenProject project;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    /**
+     * Target launch mode corresponding to {@link io.quarkus.runtime.LaunchMode} for which the dependency tree should be built.
+     * {@code io.quarkus.runtime.LaunchMode.NORMAL} is the default.
+     */
+    @Parameter(property = "mode", required = false, defaultValue = "prod")
+    String mode;
+
+    /**
+     * If specified, this parameter will cause the dependency tree to be written to the path specified, instead of writing to
+     * the console.
+     */
+    @Parameter(property = "outputFile", required = false)
+    File outputFile;
+
+    /**
+     * Whether to append outputs into the output file or overwrite it.
+     */
+    @Parameter(property = "appendOutput", required = false, defaultValue = "false")
+    boolean appendOutput;
+
+    protected MavenArtifactResolver resolver;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        BufferedWriter writer = null;
+        final Consumer<String> log;
+        if (outputFile == null) {
+            log = s -> getLog().info(s);
+        } else {
+            final BufferedWriter bw;
+            try {
+                Files.createDirectories(outputFile.toPath().getParent());
+                bw = writer = Files.newBufferedWriter(outputFile.toPath(),
+                        appendOutput && outputFile.exists() ? StandardOpenOption.APPEND : StandardOpenOption.CREATE);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to initialize file output writer", e);
+            }
+            log = s -> {
+                try {
+                    bw.write(s);
+                    bw.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to log the dependency tree to a file", e);
+                }
+            };
+        }
+        try {
+            logTree(log);
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                    getLog().debug("Failed to close the output file", e);
+                }
+            }
+        }
+    }
+
+    private void logTree(final Consumer<String> log) throws MojoExecutionException {
+        log.accept("Quarkus application " + mode.toUpperCase() + " mode build dependency tree:");
+
+        final GACTV appArtifact = new GACTV(project.getGroupId(), project.getArtifactId(), null, "pom", project.getVersion());
+        final BootstrapAppModelResolver modelResolver;
+        try {
+            modelResolver = new BootstrapAppModelResolver(resolver());
+            if (mode != null) {
+                if (mode.equalsIgnoreCase("test")) {
+                    modelResolver.setTest(true);
+                } else if (mode.equalsIgnoreCase("dev") || mode.equalsIgnoreCase("development")) {
+                    modelResolver.setDevMode(true);
+                } else if (mode.equalsIgnoreCase("prod") || mode.isEmpty()) {
+                    // ignore, that's the default
+                } else {
+                    throw new MojoExecutionException(
+                            "Parameter 'mode' was set to '" + mode + "' while expected one of 'dev', 'test' or 'prod'");
+                }
+            }
+            modelResolver.setBuildTreeLogger(log);
+            modelResolver.resolveModel(appArtifact);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to resolve application model " + appArtifact + " dependencies", e);
+        }
+    }
+
+    protected MavenArtifactResolver resolver() throws BootstrapMavenException {
+        return resolver == null
+                ? resolver = MavenArtifactResolver.builder()
+                        .setRemoteRepositoryManager(bootstrapProvider.remoteRepositoryManager())
+                        // The system needs to be initialized with the bootstrap model builder to properly interpolate system properties set on the command line
+                        // e.g. -Dquarkus.platform.version=xxx
+                        //.setRepositorySystem(bootstrapProvider.repositorySystem())
+                        // The session should be initialized with the loaded workspace
+                        //.setRepositorySystemSession(repoSession)
+                        .setRemoteRepositories(repos)
+                        // To support multimodule projects that haven't been installed
+                        .setPreferPomsFromWorkspace(true)
+                        .build()
+                : resolver;
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/DevMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/DevMojo.java
@@ -1,0 +1,1159 @@
+package io.quarkus.maven;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.aesh.readline.terminal.impl.ExecPty;
+import org.aesh.readline.terminal.impl.Pty;
+import org.aesh.terminal.Attributes;
+import org.aesh.terminal.utils.ANSI;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.BuildBase;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.utils.cli.CommandLineUtils;
+import org.apache.maven.toolchain.Toolchain;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.WorkspaceReader;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.fusesource.jansi.internal.Kernel32;
+import org.fusesource.jansi.internal.WindowsSupport;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.devmode.DependenciesFilter;
+import io.quarkus.bootstrap.model.AppArtifactKey;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.PathsCollection;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.bootstrap.resolver.maven.options.BootstrapMavenOptions;
+import io.quarkus.bootstrap.util.BootstrapUtils;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.deployment.dev.DevModeContext;
+import io.quarkus.deployment.dev.DevModeMain;
+import io.quarkus.deployment.dev.QuarkusDevModeLauncher;
+import io.quarkus.maven.MavenDevModeLauncher.Builder;
+import io.quarkus.maven.components.MavenVersionEnforcer;
+import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * The dev mojo, that runs a quarkus app in a forked process. A background compilation process is launched and any changes are
+ * automatically reflected in your running application.
+ * <p>
+ * You can use this dev mode in a remote container environment with {@code remote-dev}.
+ */
+@Mojo(name = "dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST)
+public class DevMojo extends AbstractMojo {
+
+    private static final String EXT_PROPERTIES_PATH = "META-INF/quarkus-extension.properties";
+
+    private static final String KOTLIN_MAVEN_PLUGIN_GA = "org.jetbrains.kotlin:kotlin-maven-plugin";
+
+    /**
+     * running any one of these phases means the compile phase will have been run, if these have
+     * not been run we manually run compile
+     */
+    private static final Set<String> POST_COMPILE_PHASES = Set.of(
+            "compile",
+            "process-classes",
+            "generate-test-sources",
+            "process-test-sources",
+            "generate-test-resources",
+            "process-test-resources",
+            "test-compile",
+            "process-test-classes",
+            "test",
+            "prepare-package",
+            "package",
+            "pre-integration-test",
+            "integration-test",
+            "post-integration-test",
+            "verify",
+            "install",
+            "deploy");
+
+    /**
+     * running any one of these phases means the test-compile phase will have been run, if these have
+     * not been run we manually run test-compile
+     */
+    private static final Set<String> POST_TEST_COMPILE_PHASES = Set.of(
+            "test-compile",
+            "process-test-classes",
+            "test",
+            "prepare-package",
+            "package",
+            "pre-integration-test",
+            "integration-test",
+            "post-integration-test",
+            "verify",
+            "install",
+            "deploy");
+    private static final String QUARKUS_GENERATE_CODE_GOAL = "generate-code";
+    private static final String QUARKUS_GENERATE_CODE_TESTS_GOAL = "generate-code-tests";
+
+    private static final String ORG_APACHE_MAVEN_PLUGINS = "org.apache.maven.plugins";
+    private static final String MAVEN_COMPILER_PLUGIN = "maven-compiler-plugin";
+    private static final String MAVEN_RESOURCES_PLUGIN = "maven-resources-plugin";
+    private static final String MAVEN_TOOLCHAINS_PLUGIN = "maven-toolchains-plugin";
+
+    private static final String ORG_JETBRAINS_KOTLIN = "org.jetbrains.kotlin";
+    private static final String KOTLIN_MAVEN_PLUGIN = "kotlin-maven-plugin";
+
+    /**
+     * The directory for compiled classes.
+     */
+    @Parameter(readonly = true, required = true, defaultValue = "${project.build.outputDirectory}")
+    private File outputDirectory;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    protected MavenProject project;
+
+    /**
+     * If this server should be started in debug mode. The default is to start in debug mode and listen on
+     * port 5005. Whether or not the JVM is suspended waiting for a debugger to be attached,
+     * depends on the value of {@link #suspend}.
+     * <p>
+     * {@code debug} supports the following options:
+     * <table>
+     * <tr>
+     * <td><b>Value</b></td>
+     * <td>Effect</td>
+     * </tr>
+     * <tr>
+     * <td><b>false</b></td>
+     * <td>The JVM is not started in debug mode</td>
+     * </tr>
+     * <tr>
+     * <td><b>true</b></td>
+     * <td>The JVM is started in debug mode and will be listening on {@code debugHost}:{@code debugPort}</td>
+     * </tr>
+     * <tr>
+     * <td><b>client</b></td>
+     * <td>The JVM is started in client mode, and will attempt to connect to {@code debugHost}:{@code debugPort}</td>
+     * </tr>
+     * <tr>
+     * <td><b>{port}</b></td>
+     * <td>The JVM is started in debug mode and will be listening on {@code debugHost}:{port}.</td>
+     * </tr>
+     * </table>
+     * By default, {@code debugHost} has the value "localhost", and {@code debugPort} is 5005.
+     */
+    @Parameter(defaultValue = "${debug}")
+    private String debug;
+
+    /**
+     * Whether or not the JVM launch, in debug mode, should be suspended. This parameter is only
+     * relevant when the JVM is launched in {@link #debug debug mode}. This parameter supports the
+     * following values (all the allowed values are case insensitive):
+     * <table>
+     * <th>
+     * <td>Value</td>
+     * <td>Effect</td>
+     * </th>
+     * <tr>
+     * <td>y or true</td>
+     * <td>The debug mode JVM launch is suspended</td>
+     * </tr>
+     * <tr>
+     * <td>n or false</td>
+     * <td>The debug mode JVM is started without suspending</td>
+     * </tr>
+     * </table>
+     */
+    @Parameter(defaultValue = "${suspend}")
+    private String suspend;
+
+    @Parameter(defaultValue = "${debugHost}")
+    private String debugHost;
+
+    @Parameter(defaultValue = "${debugPort}")
+    private String debugPort;
+
+    @Parameter(defaultValue = "${project.build.directory}")
+    private File buildDir;
+
+    @Parameter(defaultValue = "${project.build.sourceDirectory}")
+    private File sourceDir;
+
+    @Parameter
+    private File workingDir;
+
+    @Parameter(defaultValue = "${jvm.args}")
+    private String jvmArgs;
+
+    @Parameter(defaultValue = "${quarkus.args}")
+    private String argsString;
+
+    @Parameter
+    private Map<String, String> environmentVariables = Collections.emptyMap();
+
+    @Parameter
+    private Map<String, String> systemProperties = Collections.emptyMap();
+
+    @Parameter(defaultValue = "${session}")
+    private MavenSession session;
+
+    @Parameter(defaultValue = "TRUE")
+    private boolean deleteDevJar;
+
+    @Component
+    private MavenVersionEnforcer mavenVersionEnforcer;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Component
+    RemoteRepositoryManager remoteRepositoryManager;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Parameter(defaultValue = "${project.remotePluginRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> pluginRepos;
+
+    /**
+     * This value is intended to be set to true when some generated bytecode
+     * is erroneous causing the JVM to crash when the verify:none option is set (which is on by default)
+     */
+    @Parameter(defaultValue = "${preventnoverify}")
+    private boolean preventnoverify = false;
+
+    /**
+     * Whether changes in the projects that appear to be dependencies of the project containing the application to be launched
+     * should trigger hot-reload. By default they do.
+     */
+    @Parameter(defaultValue = "${noDeps}")
+    private boolean noDeps = false;
+
+    /**
+     * Additional parameters to pass to javac when recompiling changed
+     * source files.
+     */
+    @Parameter
+    private List<String> compilerArgs;
+
+    /**
+     * The -source argument to javac.
+     */
+    @Parameter(defaultValue = "${maven.compiler.source}")
+    private String source;
+
+    /**
+     * The -target argument to javac.
+     */
+    @Parameter(defaultValue = "${maven.compiler.target}")
+    private String target;
+
+    /**
+     * Whether or not to enforce the quarkus-maven-plugin build goal to be configured.
+     * By default, a missing build goal is considered an inconsistency (although the build goal is not <i>required</i>
+     * technically).
+     * In this case a warning will be logged and the application will not be started.
+     */
+    @Parameter(defaultValue = "${quarkus.enforceBuildGoal}")
+    private boolean enforceBuildGoal = true;
+
+    @Component
+    private WorkspaceReader wsReader;
+
+    @Component
+    private BuildPluginManager pluginManager;
+
+    @Component
+    private ToolchainManager toolchainManager;
+
+    private Map<AppArtifactKey, Plugin> pluginMap;
+
+    @Component
+    protected QuarkusBootstrapProvider bootstrapProvider;
+
+    /**
+     * console attributes, used to restore the console state
+     */
+    private Attributes attributes;
+    private int windowsAttributes;
+    private boolean windowsAttributesSet;
+    private Pty pty;
+    private boolean windowsColorSupport;
+
+    @Override
+    public void setLog(Log log) {
+        super.setLog(log);
+        MojoLogger.delegate = log;
+    }
+
+    @Override
+    public void execute() throws MojoFailureException, MojoExecutionException {
+        saveTerminalState();
+
+        mavenVersionEnforcer.ensureMavenVersion(getLog(), session);
+
+        initToolchain();
+
+        //we always want to compile if needed, so if it is run from the parent it will compile dependent projects
+        handleAutoCompile();
+
+        if (enforceBuildGoal) {
+            final PluginDescriptor pluginDescr = getPluginDescriptor();
+            final Plugin pluginDef = getConfiguredPluginOrNull(pluginDescr.getGroupId(), pluginDescr.getArtifactId());
+            if (pluginDef == null || !isGoalConfigured(pluginDef, "build")) {
+                getLog().warn("The quarkus-maven-plugin build goal was not configured for this project, " +
+                        "skipping quarkus:dev as this is assumed to be a support library. If you want to run quarkus dev" +
+                        " on this project make sure the quarkus-maven-plugin is configured with a build goal.");
+                return;
+            }
+        }
+
+        try {
+
+            DevModeRunner runner = new DevModeRunner();
+            Map<Path, Long> pomFiles = readPomFileTimestamps(runner);
+            runner.run();
+            long nextCheck = System.currentTimeMillis() + 100;
+            for (;;) {
+                //we never suspend after the first run
+                suspend = "n";
+                long sleep = Math.max(0, nextCheck - System.currentTimeMillis()) + 1;
+                Thread.sleep(sleep);
+                if (System.currentTimeMillis() > nextCheck) {
+                    nextCheck = System.currentTimeMillis() + 100;
+                    if (!runner.alive()) {
+                        restoreTerminalState();
+                        if (!runner.isExpectedExitValue()) {
+                            throw new MojoExecutionException("Dev mode process did not complete successfully");
+                        }
+                        return;
+                    }
+                    final Set<Path> changed = new HashSet<>();
+                    for (Map.Entry<Path, Long> e : pomFiles.entrySet()) {
+                        long t = Files.getLastModifiedTime(e.getKey()).toMillis();
+                        if (t > e.getValue()) {
+                            changed.add(e.getKey());
+                            pomFiles.put(e.getKey(), t);
+                        }
+                    }
+                    if (!changed.isEmpty()) {
+                        getLog().info("Changes detected to " + changed + ", restarting dev mode");
+                        final DevModeRunner newRunner;
+                        try {
+                            triggerCompile(false, false);
+                            triggerCompile(true, false);
+                            newRunner = new DevModeRunner();
+                        } catch (Exception e) {
+                            getLog().info("Could not load changed pom.xml file, changes not applied", e);
+                            continue;
+                        }
+                        runner.stop();
+                        newRunner.run();
+                        runner = newRunner;
+                    }
+                }
+
+            }
+
+        } catch (Exception e) {
+            throw new MojoFailureException("Failed to run", e);
+        }
+    }
+
+    /**
+     * if the process is forcibly killed then the terminal may be left in raw mode, which
+     * messes everything up. This attempts to fix that by saving the state so it can be restored
+     */
+    private void saveTerminalState() {
+        try {
+            windowsAttributes = WindowsSupport.getConsoleMode();
+            windowsAttributesSet = true;
+            if (windowsAttributes > 0) {
+                long hConsole = Kernel32.GetStdHandle(Kernel32.STD_INPUT_HANDLE);
+                if (hConsole != (long) Kernel32.INVALID_HANDLE_VALUE) {
+                    final int VIRTUAL_TERMINAL_PROCESSING = 0x0004; //enable color on the windows console
+                    if (Kernel32.SetConsoleMode(hConsole, windowsAttributes | VIRTUAL_TERMINAL_PROCESSING) != 0) {
+                        windowsColorSupport = true;
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            //this only works with a proper PTY based terminal
+            //Aesh creates an input pump thread, that will steal
+            //input from the dev mode process
+            try {
+                Pty pty = ExecPty.current();
+                attributes = pty.getAttr();
+                DevMojo.this.pty = pty;
+            } catch (Exception e) {
+                getLog().debug("Failed to get a local tty", e);
+            }
+        }
+    }
+
+    private void restoreTerminalState() {
+        if (windowsAttributesSet) {
+            WindowsSupport.setConsoleMode(windowsAttributes);
+        } else {
+            if (attributes == null || pty == null) {
+                return;
+            }
+            Pty finalPty = pty;
+            try (finalPty) {
+                finalPty.setAttr(attributes);
+                int height = finalPty.getSize().getHeight();
+                String sb = ANSI.MAIN_BUFFER +
+                        ANSI.CURSOR_SHOW +
+                        "\u001B[0m" +
+                        "\033[" + height + ";0H";
+                finalPty.getSlaveOutput().write(sb.getBytes(StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                getLog().error("Error restoring console state", e);
+            }
+        }
+    }
+
+    private void handleAutoCompile() throws MojoExecutionException {
+        //we check to see if there was a compile (or later) goal before this plugin
+        boolean compileNeeded = true;
+        boolean testCompileNeeded = true;
+        boolean prepareNeeded = true;
+        boolean prepareTestsNeeded = true;
+        for (String goal : session.getGoals()) {
+            if (goal.endsWith("quarkus:generate-code")) {
+                prepareNeeded = false;
+            }
+            if (goal.endsWith("quarkus:generate-code-tests")) {
+                prepareTestsNeeded = false;
+            }
+
+            if (POST_COMPILE_PHASES.contains(goal)) {
+                compileNeeded = false;
+                break;
+            }
+            if (POST_TEST_COMPILE_PHASES.contains(goal)) {
+                testCompileNeeded = false;
+                break;
+            }
+            if (goal.endsWith("quarkus:dev")) {
+                break;
+            }
+        }
+
+        //if the user did not compile we run it for them
+        if (compileNeeded) {
+            triggerCompile(false, prepareNeeded);
+        }
+        if (testCompileNeeded) {
+            try {
+                triggerCompile(true, prepareTestsNeeded);
+            } catch (Throwable t) {
+                getLog().error("Test compile failed, you will need to fix your tests before you can use continuous testing", t);
+            }
+        }
+    }
+
+    private void initToolchain() throws MojoExecutionException {
+        executeIfConfigured(ORG_APACHE_MAVEN_PLUGINS, MAVEN_TOOLCHAINS_PLUGIN, "toolchain", Collections.emptyMap());
+    }
+
+    private void triggerPrepare(boolean test) throws MojoExecutionException {
+        final PluginDescriptor pluginDescr = getPluginDescriptor();
+        executeIfConfigured(pluginDescr.getGroupId(), pluginDescr.getArtifactId(),
+                test ? QUARKUS_GENERATE_CODE_TESTS_GOAL : QUARKUS_GENERATE_CODE_GOAL,
+                Collections.singletonMap("mode", LaunchMode.DEVELOPMENT.name()));
+    }
+
+    private PluginDescriptor getPluginDescriptor() {
+        return (PluginDescriptor) getPluginContext().get("pluginDescriptor");
+    }
+
+    private void triggerCompile(boolean test, boolean prepareNeeded) throws MojoExecutionException {
+        handleResources(test);
+
+        if (prepareNeeded) {
+            triggerPrepare(test);
+        }
+
+        // compile the Kotlin sources if needed
+        executeIfConfigured(ORG_JETBRAINS_KOTLIN, KOTLIN_MAVEN_PLUGIN, test ? "test-compile" : "compile",
+                Collections.emptyMap());
+
+        // Compile the Java sources if needed
+        executeIfConfigured(ORG_APACHE_MAVEN_PLUGINS, MAVEN_COMPILER_PLUGIN, test ? "testCompile" : "compile",
+                Collections.emptyMap());
+    }
+
+    /**
+     * Execute the resources:resources goal if resources have been configured on the project
+     */
+    private void handleResources(boolean test) throws MojoExecutionException {
+        List<Resource> resources = project.getResources();
+        if (resources.isEmpty()) {
+            return;
+        }
+        executeIfConfigured(ORG_APACHE_MAVEN_PLUGINS, MAVEN_RESOURCES_PLUGIN, test ? "testResources" : "resources",
+                Collections.emptyMap());
+    }
+
+    private void executeIfConfigured(String pluginGroupId, String pluginArtifactId, String goal, Map<String, String> params)
+            throws MojoExecutionException {
+        final Plugin plugin = getConfiguredPluginOrNull(pluginGroupId, pluginArtifactId);
+        if (!isGoalConfigured(plugin, goal)) {
+            return;
+        }
+        getLog().info("Invoking " + plugin.getGroupId() + ":" + plugin.getArtifactId() + ":" + plugin.getVersion() + ":" + goal
+                + ") @ " + project.getArtifactId());
+        executeMojo(
+                plugin(
+                        groupId(pluginGroupId),
+                        artifactId(pluginArtifactId),
+                        version(plugin.getVersion()),
+                        plugin.getDependencies()),
+                goal(goal),
+                getPluginConfig(plugin, goal, params),
+                executionEnvironment(
+                        project,
+                        session,
+                        pluginManager));
+    }
+
+    public boolean isGoalConfigured(Plugin plugin, String goal) {
+        if (plugin == null) {
+            return false;
+        }
+        for (PluginExecution pluginExecution : plugin.getExecutions()) {
+            if (pluginExecution.getGoals().contains(goal)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Xpp3Dom getPluginConfig(Plugin plugin, String goal, Map<String, String> params) throws MojoExecutionException {
+        Xpp3Dom mergedConfig = null;
+        if (!plugin.getExecutions().isEmpty()) {
+            for (PluginExecution exec : plugin.getExecutions()) {
+                if (exec.getConfiguration() != null && exec.getGoals().contains(goal)) {
+                    mergedConfig = mergedConfig == null ? (Xpp3Dom) exec.getConfiguration()
+                            : Xpp3Dom.mergeXpp3Dom(mergedConfig, (Xpp3Dom) exec.getConfiguration(), true);
+                }
+            }
+        }
+
+        if ((Xpp3Dom) plugin.getConfiguration() != null) {
+            mergedConfig = mergedConfig == null ? (Xpp3Dom) plugin.getConfiguration()
+                    : Xpp3Dom.mergeXpp3Dom(mergedConfig, (Xpp3Dom) plugin.getConfiguration(), true);
+        }
+
+        final Xpp3Dom configuration = configuration();
+        if (mergedConfig != null) {
+            Set<String> supportedParams = null;
+            // Filter out `test*` configurations
+            for (Xpp3Dom child : mergedConfig.getChildren()) {
+                if (child.getName().startsWith("test")) {
+                    continue;
+                }
+                if (supportedParams == null) {
+                    supportedParams = getMojoDescriptor(plugin, goal).getParameterMap().keySet();
+                }
+                if (supportedParams.contains(child.getName())) {
+                    configuration.addChild(child);
+                }
+            }
+        }
+
+        for (Map.Entry<String, String> param : params.entrySet()) {
+            final Xpp3Dom p = new Xpp3Dom(param.getKey());
+            p.setValue(param.getValue());
+            configuration.addChild(p);
+        }
+
+        return configuration;
+    }
+
+    private MojoDescriptor getMojoDescriptor(Plugin plugin, String goal) throws MojoExecutionException {
+        try {
+            return pluginManager.getMojoDescriptor(plugin, goal, pluginRepos, repoSession);
+        } catch (Exception e) {
+            throw new MojoExecutionException(
+                    "Failed to obtain descriptor for Maven plugin " + plugin.getId() + " goal " + goal, e);
+        }
+    }
+
+    private Plugin getConfiguredPluginOrNull(String groupId, String artifactId) {
+        if (pluginMap == null) {
+            pluginMap = new HashMap<>();
+            // the original plugin keys may include property expressions, so we can't rely on the exact groupId:artifactId keys
+            for (Plugin p : project.getBuildPlugins()) {
+                pluginMap.put(new AppArtifactKey(p.getGroupId(), p.getArtifactId()), p);
+            }
+        }
+        return pluginMap.get(new AppArtifactKey(groupId, artifactId));
+    }
+
+    private Map<Path, Long> readPomFileTimestamps(DevModeRunner runner) throws IOException {
+        Map<Path, Long> ret = new HashMap<>();
+        for (Path i : runner.pomFiles()) {
+            ret.put(i, Files.getLastModifiedTime(i).toMillis());
+        }
+        return ret;
+    }
+
+    private String getSourceEncoding() {
+        Object sourceEncodingProperty = project.getProperties().get("project.build.sourceEncoding");
+        if (sourceEncodingProperty != null) {
+            return (String) sourceEncodingProperty;
+        }
+        return null;
+    }
+
+    private void addProject(MavenDevModeLauncher.Builder builder, WorkspaceModule module, boolean root) throws Exception {
+
+        String projectDirectory;
+        Set<Path> sourcePaths;
+        String classesPath = null;
+        Set<Path> resourcePaths;
+        Set<Path> testSourcePaths;
+        String testClassesPath;
+        Set<Path> testResourcePaths;
+        List<Profile> activeProfiles = Collections.emptyList();
+
+        final MavenProject mavenProject = session.getProjectMap().get(
+                String.format("%s:%s:%s", module.getId().getGroupId(), module.getId().getArtifactId(),
+                        module.getId().getVersion()));
+        if (mavenProject == null) {
+            projectDirectory = module.getModuleDir().getAbsolutePath();
+            sourcePaths = module.getMainSources().stream().map(src -> src.getSourceDir().toPath().toAbsolutePath())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            testSourcePaths = module.getTestSources().stream().map(src -> src.getSourceDir().toPath().toAbsolutePath())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+        } else {
+            projectDirectory = mavenProject.getBasedir().getPath();
+            sourcePaths = mavenProject.getCompileSourceRoots().stream()
+                    .map(Paths::get)
+                    .map(Path::toAbsolutePath)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            testSourcePaths = mavenProject.getTestCompileSourceRoots().stream()
+                    .map(Paths::get)
+                    .map(Path::toAbsolutePath)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            activeProfiles = mavenProject.getActiveProfiles();
+        }
+
+        final Path sourceParent;
+        if (module.getMainSources().isEmpty()) {
+            if (module.getMainResources().isEmpty()) {
+                throw new MojoExecutionException("The project does not appear to contain any sources or resources");
+            }
+            sourceParent = module.getMainResources().iterator().next().getSourceDir().toPath().toAbsolutePath().getParent();
+        } else {
+            sourceParent = module.getMainSources().iterator().next().getSourceDir().toPath().toAbsolutePath().getParent();
+        }
+
+        Path classesDir = module.getMainSources().iterator().next().getDestinationDir().toPath().toAbsolutePath();
+        if (Files.isDirectory(classesDir)) {
+            classesPath = classesDir.toString();
+        }
+        Path testClassesDir = module.getTestSources().iterator().next().getDestinationDir().toPath().toAbsolutePath();
+        testClassesPath = testClassesDir.toString();
+
+        resourcePaths = module.getMainResources().stream().map(src -> src.getSourceDir().toPath().toAbsolutePath())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        testResourcePaths = module.getTestResources().stream().map(src -> src.getSourceDir().toPath().toAbsolutePath())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        // Add the resources and test resources from the profiles
+        for (Profile profile : activeProfiles) {
+            final BuildBase build = profile.getBuild();
+            if (build != null) {
+                resourcePaths.addAll(
+                        build.getResources().stream()
+                                .map(Resource::getDirectory)
+                                .map(Paths::get)
+                                .map(Path::toAbsolutePath)
+                                .collect(Collectors.toList()));
+                testResourcePaths.addAll(
+                        build.getTestResources().stream()
+                                .map(Resource::getDirectory)
+                                .map(Paths::get)
+                                .map(Path::toAbsolutePath)
+                                .collect(Collectors.toList()));
+            }
+        }
+
+        if (classesPath == null && (!sourcePaths.isEmpty() || !resourcePaths.isEmpty())) {
+            throw new MojoExecutionException("Hot reloadable dependency " + module.getId()
+                    + " has not been compiled yet (the classes directory " + classesDir + " does not exist)");
+        }
+
+        Path targetDir = Paths.get(project.getBuild().getDirectory());
+
+        DevModeContext.ModuleInfo moduleInfo = new DevModeContext.ModuleInfo.Builder()
+                .setArtifactKey(new GACT(module.getId().getGroupId(), module.getId().getArtifactId()))
+                .setName(module.getId().getArtifactId())
+                .setProjectDirectory(projectDirectory)
+                .setSourcePaths(PathsCollection.from(sourcePaths))
+                .setClassesPath(classesPath)
+                .setResourcesOutputPath(classesPath)
+                .setResourcePaths(PathsCollection.from(resourcePaths))
+                .setSourceParents(PathsCollection.of(sourceParent.toAbsolutePath()))
+                .setPreBuildOutputDir(targetDir.resolve("generated-sources").toAbsolutePath().toString())
+                .setTargetDir(targetDir.toAbsolutePath().toString())
+                .setTestSourcePaths(PathsCollection.from(testSourcePaths))
+                .setTestClassesPath(testClassesPath)
+                .setTestResourcesOutputPath(testClassesPath)
+                .setTestResourcePaths(PathsCollection.from(testResourcePaths))
+                .build();
+
+        if (root) {
+            builder.mainModule(moduleInfo);
+        } else {
+            builder.dependency(moduleInfo);
+        }
+    }
+
+    private class DevModeRunner {
+
+        final QuarkusDevModeLauncher launcher;
+        private Process process;
+
+        private DevModeRunner() throws Exception {
+            launcher = newLauncher();
+        }
+
+        Collection<Path> pomFiles() {
+            return launcher.watchedBuildFiles();
+        }
+
+        boolean alive() {
+            return process != null && process.isAlive();
+        }
+
+        int exitValue() {
+            return process == null ? -1 : process.exitValue();
+        }
+
+        boolean isExpectedExitValue() {
+            // '130' is what the process exits with in remote-dev mode under bash
+            return exitValue() == 0 || exitValue() == 130;
+        }
+
+        void run() throws Exception {
+            // Display the launch command line in dev mode
+            if (getLog().isDebugEnabled()) {
+                getLog().debug("Launching JVM with command line: " + String.join(" ", launcher.args()));
+            }
+            final ProcessBuilder processBuilder = new ProcessBuilder(launcher.args())
+                    .redirectErrorStream(true)
+                    .inheritIO()
+                    .directory(workingDir == null ? project.getBasedir() : workingDir);
+            if (!environmentVariables.isEmpty()) {
+                processBuilder.environment().putAll(environmentVariables);
+            }
+            process = processBuilder.start();
+
+            //https://github.com/quarkusio/quarkus/issues/232
+            Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    process.destroy();
+                    try {
+                        process.waitFor();
+                    } catch (InterruptedException e) {
+                        getLog().warn("Unable to properly wait for dev-mode end", e);
+                    }
+                }
+            }, "Development Mode Shutdown Hook"));
+        }
+
+        void stop() throws InterruptedException {
+            process.destroy();
+            process.waitFor();
+        }
+    }
+
+    private QuarkusDevModeLauncher newLauncher() throws Exception {
+        String java = null;
+        // See if a toolchain is configured
+        if (toolchainManager != null) {
+            Toolchain toolchain = toolchainManager.getToolchainFromBuildContext("jdk", session);
+            if (toolchain != null) {
+                java = toolchain.findTool("java");
+                getLog().info("JVM from toolchain: " + java);
+            }
+        }
+
+        final MavenDevModeLauncher.Builder builder = MavenDevModeLauncher.builder(java, getLog())
+                .preventnoverify(preventnoverify)
+                .buildDir(buildDir)
+                .outputDir(outputDirectory)
+                .suspend(suspend)
+                .debug(debug)
+                .debugHost(debugHost)
+                .debugPort(debugPort)
+                .deleteDevJar(deleteDevJar);
+
+        setJvmArgs(builder);
+        if (windowsColorSupport) {
+            builder.jvmArgs("-Dio.quarkus.force-color-support=true");
+        }
+
+        builder.projectDir(project.getFile().getParentFile());
+        builder.buildSystemProperties((Map) project.getProperties());
+
+        builder.applicationName(project.getArtifactId());
+        builder.applicationVersion(project.getVersion());
+
+        builder.sourceEncoding(getSourceEncoding());
+
+        // Set compilation flags.  Try the explicitly given configuration first.  Otherwise,
+        // refer to the configuration of the Maven Compiler Plugin.
+        final Optional<Xpp3Dom> compilerPluginConfiguration = findCompilerPluginConfiguration();
+        if (compilerArgs != null) {
+            builder.compilerOptions(compilerArgs);
+        } else if (compilerPluginConfiguration.isPresent()) {
+            final Xpp3Dom compilerPluginArgsConfiguration = compilerPluginConfiguration.get().getChild("compilerArgs");
+            if (compilerPluginArgsConfiguration != null) {
+                List<String> compilerPluginArgs = new ArrayList<>();
+                for (Xpp3Dom argConfiguration : compilerPluginArgsConfiguration.getChildren()) {
+                    compilerPluginArgs.add(argConfiguration.getValue());
+                }
+                // compilerArgs can also take a value without using arg
+                if (compilerPluginArgsConfiguration.getValue() != null
+                        && !compilerPluginArgsConfiguration.getValue().isEmpty()) {
+                    compilerPluginArgs.add(compilerPluginArgsConfiguration.getValue().trim());
+                }
+                builder.compilerOptions(compilerPluginArgs);
+            }
+        }
+        if (source != null) {
+            builder.sourceJavaVersion(source);
+        } else if (compilerPluginConfiguration.isPresent()) {
+            final Xpp3Dom javacSourceVersion = compilerPluginConfiguration.get().getChild("source");
+            if (javacSourceVersion != null && javacSourceVersion.getValue() != null
+                    && !javacSourceVersion.getValue().trim().isEmpty()) {
+                builder.sourceJavaVersion(javacSourceVersion.getValue().trim());
+            }
+        }
+        if (target != null) {
+            builder.targetJavaVersion(target);
+        } else if (compilerPluginConfiguration.isPresent()) {
+            final Xpp3Dom javacTargetVersion = compilerPluginConfiguration.get().getChild("target");
+            if (javacTargetVersion != null && javacTargetVersion.getValue() != null
+                    && !javacTargetVersion.getValue().trim().isEmpty()) {
+                builder.targetJavaVersion(javacTargetVersion.getValue().trim());
+            }
+        }
+
+        setKotlinSpecificFlags(builder);
+
+        // path to the serialized application model
+        final Path appModelLocation = resolveSerializedModelLocation();
+
+        ApplicationModel appModel = bootstrapProvider
+                .getResolvedApplicationModel(QuarkusBootstrapProvider.getProjectId(project), LaunchMode.DEVELOPMENT);
+        if (appModel != null) {
+            bootstrapProvider.close();
+        } else {
+            final MavenArtifactResolver.Builder resolverBuilder = MavenArtifactResolver.builder()
+                    .setRepositorySystem(repoSystem)
+                    .setRemoteRepositories(repos)
+                    .setRemoteRepositoryManager(remoteRepositoryManager)
+                    .setWorkspaceDiscovery(true);
+
+            // if it already exists, it may be a reload triggered by a change in a POM
+            // in which case we should not be using the original Maven session
+            boolean reinitializeMavenSession = Files.exists(appModelLocation);
+            if (reinitializeMavenSession) {
+                Files.delete(appModelLocation);
+            } else {
+                // we can re-use the original Maven session
+                resolverBuilder.setRepositorySystemSession(repoSession);
+            }
+
+            appModel = new BootstrapAppModelResolver(resolverBuilder.build())
+                    .setDevMode(true)
+                    .setCollectReloadableDependencies(!noDeps)
+                    .resolveModel(new GACTV(project.getGroupId(), project.getArtifactId(), null, "jar", project.getVersion()));
+        }
+
+        // serialize the app model to avoid re-resolving it in the dev process
+        BootstrapUtils.serializeAppModel(appModel, appModelLocation);
+        builder.jvmArgs("-D" + BootstrapConstants.SERIALIZED_APP_MODEL + "=" + appModelLocation);
+
+        if (noDeps) {
+            addProject(builder, appModel.getApplicationModule(), true);
+            appModel.getApplicationModule().getBuildFiles().forEach(p -> builder.watchedBuildFile(p));
+            builder.localArtifact(new AppArtifactKey(project.getGroupId(), project.getArtifactId()));
+        } else {
+            for (WorkspaceModule project : DependenciesFilter.getReloadableModules(appModel)) {
+                addProject(builder, project, project == appModel.getApplicationModule());
+                project.getBuildFiles().forEach(p -> builder.watchedBuildFile(p));
+                builder.localArtifact(new AppArtifactKey(project.getId().getGroupId(), project.getId().getArtifactId()));
+            }
+        }
+
+        addQuarkusDevModeDeps(builder);
+
+        //in most cases these are not used, however they need to be present for some
+        //parent-first cases such as logging
+        //first we go through and get all the parent first artifacts
+        Set<AppArtifactKey> parentFirstArtifacts = new HashSet<>();
+        for (Artifact appDep : project.getArtifacts()) {
+            if (appDep.getArtifactHandler().getExtension().equals("jar") && appDep.getFile().isFile()) {
+                try (ZipFile file = new ZipFile(appDep.getFile())) {
+                    ZipEntry entry = file.getEntry(EXT_PROPERTIES_PATH);
+                    if (entry != null) {
+                        Properties p = new Properties();
+                        try (InputStream inputStream = file.getInputStream(entry)) {
+                            p.load(inputStream);
+                            String parentFirst = p.getProperty(ApplicationModel.PARENT_FIRST_ARTIFACTS);
+                            if (parentFirst != null) {
+                                String[] artifacts = parentFirst.split(",");
+                                for (String artifact : artifacts) {
+                                    parentFirstArtifacts.add(new AppArtifactKey(artifact.split(":")));
+                                }
+                            }
+                        }
+
+                    }
+                }
+            }
+        }
+        for (Artifact appDep : project.getArtifacts()) {
+            // only add the artifact if it's present in the dev mode context
+            // we need this to avoid having jars on the classpath multiple times
+            AppArtifactKey key = new AppArtifactKey(appDep.getGroupId(), appDep.getArtifactId(),
+                    appDep.getClassifier(), appDep.getArtifactHandler().getExtension());
+            if (!builder.isLocal(key) && parentFirstArtifacts.contains(key)) {
+                builder.classpathEntry(appDep.getFile());
+            }
+        }
+
+        builder.baseName(project.getBuild().getFinalName());
+
+        modifyDevModeContext(builder);
+
+        if (argsString != null) {
+            builder.applicationArgs(argsString);
+        }
+        propagateUserProperties(builder);
+
+        return builder.build();
+    }
+
+    private void setJvmArgs(Builder builder) throws Exception {
+        String jvmArgs = this.jvmArgs;
+        if (!systemProperties.isEmpty()) {
+            final StringBuilder buf = new StringBuilder();
+            if (jvmArgs != null) {
+                buf.append(jvmArgs);
+            }
+            for (Map.Entry<String, String> prop : systemProperties.entrySet()) {
+                buf.append(" -D").append(prop.getKey()).append("=\"").append(prop.getValue()).append("\"");
+            }
+            jvmArgs = buf.toString();
+        }
+        if (jvmArgs != null) {
+            builder.jvmArgs(Arrays.asList(CommandLineUtils.translateCommandline(jvmArgs)));
+        }
+
+    }
+
+    private void propagateUserProperties(MavenDevModeLauncher.Builder builder) {
+        Properties userProps = BootstrapMavenOptions.newInstance().getSystemProperties();
+        if (userProps == null) {
+            return;
+        }
+        final StringBuilder buf = new StringBuilder();
+        buf.append("-D");
+        for (Object o : userProps.keySet()) {
+            String name = o.toString();
+            final String value = userProps.getProperty(name);
+            buf.setLength(2);
+            buf.append(name);
+            if (value != null && !value.isEmpty()) {
+                buf.append('=');
+                buf.append(value);
+            }
+            builder.jvmArgs(buf.toString());
+        }
+    }
+
+    private void addQuarkusDevModeDeps(MavenDevModeLauncher.Builder builder)
+            throws MojoExecutionException, DependencyResolutionException {
+        final String pomPropsPath = "META-INF/maven/io.quarkus/quarkus-core-deployment/pom.properties";
+        final InputStream devModePomPropsIs = DevModeMain.class.getClassLoader().getResourceAsStream(pomPropsPath);
+        if (devModePomPropsIs == null) {
+            throw new MojoExecutionException("Failed to locate " + pomPropsPath + " on the classpath");
+        }
+        final Properties devModeProps = new Properties();
+        try (InputStream is = devModePomPropsIs) {
+            devModeProps.load(is);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to load " + pomPropsPath + " from the classpath", e);
+        }
+        final String devModeGroupId = devModeProps.getProperty("groupId");
+        if (devModeGroupId == null) {
+            throw new MojoExecutionException("Classpath resource " + pomPropsPath + " is missing groupId");
+        }
+        final String devModeArtifactId = devModeProps.getProperty("artifactId");
+        if (devModeArtifactId == null) {
+            throw new MojoExecutionException("Classpath resource " + pomPropsPath + " is missing artifactId");
+        }
+        final String devModeVersion = devModeProps.getProperty("version");
+        if (devModeVersion == null) {
+            throw new MojoExecutionException("Classpath resource " + pomPropsPath + " is missing version");
+        }
+
+        final DefaultArtifact devModeJar = new DefaultArtifact(devModeGroupId, devModeArtifactId, "jar", devModeVersion);
+        final DependencyResult cpRes = repoSystem.resolveDependencies(repoSession,
+                new DependencyRequest()
+                        .setCollectRequest(
+                                new CollectRequest()
+                                        .setRoot(new org.eclipse.aether.graph.Dependency(devModeJar, JavaScopes.RUNTIME))
+                                        .setRepositories(repos)));
+
+        for (ArtifactResult appDep : cpRes.getArtifactResults()) {
+            //we only use the launcher for launching from the IDE, we need to exclude it
+            if (!(appDep.getArtifact().getGroupId().equals("io.quarkus")
+                    && appDep.getArtifact().getArtifactId().equals("quarkus-ide-launcher"))) {
+                if (appDep.getArtifact().getGroupId().equals("io.quarkus")
+                        && appDep.getArtifact().getArtifactId().equals("quarkus-class-change-agent")) {
+                    builder.jvmArgs("-javaagent:" + appDep.getArtifact().getFile().getAbsolutePath());
+                } else {
+                    builder.classpathEntry(appDep.getArtifact().getFile());
+                }
+            }
+        }
+    }
+
+    private void setKotlinSpecificFlags(MavenDevModeLauncher.Builder builder) {
+        Plugin kotlinMavenPlugin = null;
+        for (Plugin plugin : project.getBuildPlugins()) {
+            if (plugin.getKey().equals(KOTLIN_MAVEN_PLUGIN_GA)) {
+                kotlinMavenPlugin = plugin;
+                break;
+            }
+        }
+
+        if (kotlinMavenPlugin == null) {
+            return;
+        }
+
+        getLog().debug("Kotlin Maven plugin detected");
+
+        List<String> compilerPluginArtifacts = new ArrayList<>();
+        List<Dependency> dependencies = kotlinMavenPlugin.getDependencies();
+        for (Dependency dependency : dependencies) {
+            try {
+                ArtifactResult resolvedArtifact = repoSystem.resolveArtifact(repoSession,
+                        new ArtifactRequest()
+                                .setArtifact(new DefaultArtifact(dependency.getGroupId(), dependency.getArtifactId(),
+                                        dependency.getClassifier(), dependency.getType(), dependency.getVersion()))
+                                .setRepositories(repos));
+
+                compilerPluginArtifacts.add(resolvedArtifact.getArtifact().getFile().toPath().toAbsolutePath().toString());
+            } catch (ArtifactResolutionException e) {
+                getLog().warn("Unable to properly setup dev-mode for Kotlin", e);
+                return;
+            }
+        }
+        builder.compilerPluginArtifacts(compilerPluginArtifacts);
+
+        List<String> options = new ArrayList<>();
+        Xpp3Dom compilerPluginConfiguration = (Xpp3Dom) kotlinMavenPlugin.getConfiguration();
+        if (compilerPluginConfiguration != null) {
+            Xpp3Dom compilerPluginArgsConfiguration = compilerPluginConfiguration.getChild("pluginOptions");
+            if (compilerPluginArgsConfiguration != null) {
+                for (Xpp3Dom argConfiguration : compilerPluginArgsConfiguration.getChildren()) {
+                    options.add(argConfiguration.getValue());
+                }
+            }
+        }
+        builder.compilerPluginOptions(options);
+    }
+
+    protected void modifyDevModeContext(MavenDevModeLauncher.Builder builder) {
+
+    }
+
+    private Optional<Xpp3Dom> findCompilerPluginConfiguration() {
+        for (final Plugin plugin : project.getBuildPlugins()) {
+            if (!plugin.getKey().equals("org.apache.maven.plugins:maven-compiler-plugin")) {
+                continue;
+            }
+            final Xpp3Dom compilerPluginConfiguration = (Xpp3Dom) plugin.getConfiguration();
+            if (compilerPluginConfiguration != null) {
+                return Optional.of(compilerPluginConfiguration);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Path resolveSerializedModelLocation() {
+        final Path p = BootstrapUtils.resolveSerializedAppModelPath(Paths.get(project.getBuild().getDirectory()));
+        p.toFile().deleteOnExit();
+        return p;
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/GenerateCodeMojo.java
@@ -1,0 +1,96 @@
+package io.quarkus.maven;
+
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.function.Consumer;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.model.PathsCollection;
+import io.quarkus.runtime.LaunchMode;
+
+// in the PROCESS_RESOURCES phase because we want the config to be available
+// by the time code gen providers are triggered (the resources plugin copies the config files
+// to the destination location at the beginning of this phase)
+@Mojo(name = "generate-code", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class GenerateCodeMojo extends QuarkusBootstrapMojo {
+
+    /**
+     * Skip the execution of this mojo
+     */
+    @Parameter(defaultValue = "false", property = "quarkus.generate-code.skip", alias = "quarkus.prepare.skip")
+    private boolean skipSourceGeneration = false;
+
+    @Parameter(defaultValue = "NORMAL", property = "launchMode")
+    String mode;
+
+    @Override
+    protected boolean beforeExecute() throws MojoExecutionException, MojoFailureException {
+        if (mavenProject().getPackaging().equals("pom")) {
+            getLog().info("Type of the artifact is POM, skipping build goal");
+            return false;
+        }
+        if (skipSourceGeneration) {
+            getLog().info("Skipping Quarkus code generation");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected void doExecute() throws MojoExecutionException, MojoFailureException {
+        String projectDir = mavenProject().getBasedir().getAbsolutePath();
+        Path sourcesDir = Paths.get(projectDir, "src", "main");
+        generateCode(sourcesDir, path -> mavenProject().addCompileSourceRoot(path.toString()), false);
+    }
+
+    void generateCode(Path sourcesDir,
+            Consumer<Path> sourceRegistrar,
+            boolean test) throws MojoFailureException, MojoExecutionException {
+
+        final LaunchMode launchMode = test ? LaunchMode.TEST : LaunchMode.valueOf(mode);
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Bootstrapping Quarkus application in mode " + launchMode);
+        }
+
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        try {
+
+            final CuratedApplication curatedApplication = bootstrapApplication(launchMode);
+
+            QuarkusClassLoader deploymentClassLoader = curatedApplication.createDeploymentClassLoader();
+            Thread.currentThread().setContextClassLoader(deploymentClassLoader);
+
+            final Class<?> codeGenerator = deploymentClassLoader.loadClass("io.quarkus.deployment.CodeGenerator");
+            final Method initAndRun = codeGenerator.getMethod("initAndRun", ClassLoader.class, PathsCollection.class,
+                    Path.class,
+                    Path.class,
+                    Consumer.class, ApplicationModel.class, Properties.class, String.class);
+            initAndRun.invoke(null, deploymentClassLoader,
+                    PathsCollection.of(sourcesDir),
+                    generatedSourcesDir(test),
+                    buildDir().toPath(),
+                    sourceRegistrar,
+                    curatedApplication.getApplicationModel(),
+                    mavenProject().getProperties(), launchMode.name());
+        } catch (Exception any) {
+            throw new MojoExecutionException("Quarkus code generation phase has failed", any);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
+    }
+
+    private Path generatedSourcesDir(boolean test) {
+        return test ? buildDir().toPath().resolve("generated-test-sources") : buildDir().toPath().resolve("generated-sources");
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/GenerateCodeTestsMojo.java
@@ -1,0 +1,20 @@
+package io.quarkus.maven;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+@Mojo(name = "generate-code-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class GenerateCodeTestsMojo extends GenerateCodeMojo {
+    @Override
+    protected void doExecute() throws MojoExecutionException, MojoFailureException {
+        String projectDir = mavenProject().getBasedir().getAbsolutePath();
+        Path testSources = Paths.get(projectDir, "src", "test");
+        generateCode(testSources, path -> mavenProject().addTestCompileSourceRoot(path.toString()), true);
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/GoOfflineMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/GoOfflineMojo.java
@@ -1,0 +1,141 @@
+package io.quarkus.maven;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalWorkspace;
+import io.quarkus.bootstrap.util.IoUtils;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.runtime.LaunchMode;
+
+/**
+ * This goal downloads all the Maven artifact dependencies required to build, run, test and
+ * launch the application dev mode.
+ */
+@Mojo(name = "go-offline")
+public class GoOfflineMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    protected MavenProject project;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Component
+    RemoteRepositoryManager remoteRepositoryManager;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        final Artifact pom = new DefaultArtifact(project.getArtifact().getGroupId(),
+                project.getArtifactId(),
+                ArtifactCoords.TYPE_POM,
+                project.getVersion());
+
+        final MavenArtifactResolver resolver = getResolver();
+        final DependencyNode root;
+        try {
+            root = resolver.collectDependencies(pom, Collections.emptyList()).getRoot();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to collect dependencies of " + pom, e);
+        }
+
+        final List<Path> createdDirs = new ArrayList<>();
+        try {
+            ensureResolvableModule(root, resolver.getMavenContext().getWorkspace(), createdDirs);
+            final ArtifactCoords appArtifact = new GACTV(pom.getGroupId(), pom.getArtifactId(), pom.getClassifier(),
+                    pom.getExtension(), pom.getVersion());
+            resolveAppModel(resolver, appArtifact, LaunchMode.NORMAL);
+            resolveAppModel(resolver, appArtifact, LaunchMode.DEVELOPMENT);
+            resolveAppModel(resolver, appArtifact, LaunchMode.TEST);
+        } finally {
+            for (Path d : createdDirs) {
+                IoUtils.recursiveDelete(d);
+            }
+        }
+    }
+
+    private void resolveAppModel(final MavenArtifactResolver resolver, final ArtifactCoords appArtifact, LaunchMode mode)
+            throws MojoExecutionException {
+        final BootstrapAppModelResolver appModelResolver = new BootstrapAppModelResolver(resolver);
+        if (mode == LaunchMode.DEVELOPMENT) {
+            appModelResolver.setDevMode(true);
+        } else if (mode == LaunchMode.TEST) {
+            appModelResolver.setTest(true);
+        }
+        try {
+            appModelResolver.resolveModel(appArtifact);
+        } catch (AppModelResolverException e) {
+            throw new MojoExecutionException("Failed to resolve Quarkus application model for " + project.getArtifact(), e);
+        }
+    }
+
+    private MavenArtifactResolver getResolver() throws MojoExecutionException {
+        try {
+            return MavenArtifactResolver.builder()
+                    .setRemoteRepositoryManager(remoteRepositoryManager)
+                    .setRemoteRepositories(repos)
+                    .setPreferPomsFromWorkspace(true)
+                    .build();
+        } catch (BootstrapMavenException e) {
+            throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
+        }
+    }
+
+    private static void ensureResolvableModule(DependencyNode node, LocalWorkspace workspace, List<Path> createdDirs)
+            throws MojoExecutionException {
+        Artifact artifact = node.getArtifact();
+        if (artifact != null) {
+            final LocalProject module = workspace.getProject(artifact.getGroupId(), artifact.getArtifactId());
+            if (module != null && !module.getRawModel().getPackaging().equals(ArtifactCoords.TYPE_POM)) {
+                final Path classesDir = module.getClassesDir();
+                if (!Files.exists(classesDir)) {
+                    Path topDirToCreate = classesDir;
+                    while (!Files.exists(topDirToCreate.getParent())) {
+                        topDirToCreate = topDirToCreate.getParent();
+                    }
+                    try {
+                        Files.createDirectories(classesDir);
+                        createdDirs.add(topDirToCreate);
+                    } catch (IOException e) {
+                        throw new MojoExecutionException("Failed to create " + classesDir, e);
+                    }
+                }
+            }
+        }
+        for (DependencyNode c : node.getChildren()) {
+            ensureResolvableModule(c, workspace, createdDirs);
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/ListCategoriesMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/ListCategoriesMojo.java
@@ -1,0 +1,45 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.devtools.commands.ListCategories;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+
+/**
+ * List extension categories, which a user can use to filter extensions.
+ */
+@Mojo(name = "list-categories", requiresProject = false)
+public class ListCategoriesMojo extends QuarkusProjectMojoBase {
+
+    private static final String DEFAULT_FORMAT = "concise";
+
+    /**
+     * Select the output format among 'name' (display the name only) and 'full'
+     * (includes a verbose name and a description).
+     */
+    @Parameter(property = "format", defaultValue = DEFAULT_FORMAT)
+    protected String format;
+
+    @Override
+    public void doExecute(final QuarkusProject quarkusProject, final MessageWriter log) throws MojoExecutionException {
+        try {
+            ListCategories listExtensions = new ListCategories(quarkusProject)
+                    .format(format);
+            listExtensions.execute();
+
+            if (DEFAULT_FORMAT.equalsIgnoreCase(format)) {
+                log.info("");
+                log.info(ListCategories.MORE_INFO_HINT, "-Dformat=full");
+            }
+            log.info("");
+            log.info(ListCategories.LIST_EXTENSIONS_HINT,
+                    "`./mvnw quarkus:list-extensions -Dcategory=\"categoryId\"`");
+
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to list extension categories", e);
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/ListExtensionsMojo.java
@@ -1,0 +1,80 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.devtools.commands.ListExtensions;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+
+/**
+ * List the available extensions.
+ * You can add one or several extensions in one go, with the 2 following mojos:
+ * {@code add-extensions} and {@code add-extension}.
+ * You can list all extension or just installable. Choose between 3 output formats: name, concise and full.
+ */
+@Mojo(name = "list-extensions", requiresProject = false)
+public class ListExtensionsMojo extends QuarkusProjectMojoBase {
+
+    private static final String DEFAULT_FORMAT = "concise";
+
+    /**
+     * List all extensions or just the installable.
+     */
+    @Parameter(property = "all", defaultValue = "true")
+    protected boolean all;
+
+    /**
+     * Select the output format among 'id' (display the artifactId only), 'concise' (display name and artifactId) and 'full'
+     * (concise format and version related columns).
+     */
+    @Parameter(property = "format", defaultValue = DEFAULT_FORMAT)
+    protected String format;
+
+    /**
+     * Search filter on extension list. The format is based on Java Pattern.
+     */
+    @Parameter(property = "searchPattern")
+    protected String searchPattern;
+
+    /**
+     * Only list extensions from given category.
+     */
+    @Parameter(property = "category")
+    protected String category;
+
+    /**
+     * List the already installed extensions
+     */
+    @Parameter(property = "installed", defaultValue = "false")
+    protected boolean installed;
+
+    @Override
+    public void doExecute(final QuarkusProject quarkusProject, final MessageWriter log) throws MojoExecutionException {
+        try {
+            ListExtensions listExtensions = new ListExtensions(quarkusProject)
+                    .all(all)
+                    .format(format)
+                    .search(searchPattern)
+                    .category(category)
+                    .installed(installed);
+            listExtensions.execute();
+
+            if (DEFAULT_FORMAT.equalsIgnoreCase(format)) {
+                log.info("");
+                log.info(ListExtensions.MORE_INFO_HINT, "-Dformat=full");
+            }
+            if (!installed && (category == null || category.isBlank())) {
+                log.info("");
+                log.info(ListExtensions.FILTER_HINT, "-Dcategory=\"categoryId\"");
+            }
+            log.info("");
+            log.info(ListExtensions.ADD_EXTENSION_HINT,
+                    "pom.xml", "./mvnw quarkus:add-extension -Dextensions=\"artifactId\"");
+
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to list extensions", e);
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/ListPlatformsMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/ListPlatformsMojo.java
@@ -1,0 +1,43 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.devtools.commands.ListPlatforms;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.registry.Constants;
+
+/**
+ * List imported and optionally other platforms available for the project.
+ */
+@Mojo(name = "list-platforms", requiresProject = false)
+public class ListPlatformsMojo extends QuarkusProjectMojoBase {
+
+    /**
+     * List the already installed extensions
+     */
+    @Parameter(property = "installed", defaultValue = "false")
+    protected boolean installed;
+
+    @Override
+    public void doExecute(final QuarkusProject quarkusProject, final MessageWriter log) throws MojoExecutionException {
+        if (installed) {
+            getImportedPlatforms().forEach(coords -> {
+                final StringBuilder buf = new StringBuilder();
+                buf.append(coords.getGroupId()).append(":")
+                        .append(coords.getArtifactId().substring(0,
+                                coords.getArtifactId().length() - Constants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX.length()))
+                        .append("::pom:").append(coords.getVersion());
+                log.info(buf.toString());
+            });
+            return;
+        }
+        try {
+            new ListPlatforms(quarkusProject).execute();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to list platforms", e);
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/MavenDevModeLauncher.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/MavenDevModeLauncher.java
@@ -1,0 +1,52 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugin.logging.Log;
+
+import io.quarkus.deployment.dev.QuarkusDevModeLauncher;
+
+public class MavenDevModeLauncher extends QuarkusDevModeLauncher {
+
+    /**
+     * Initializes the launcher builder
+     *
+     * @param java path to the java, may be null
+     * @param log the logger
+     * @return launcher builder
+     */
+    public static Builder builder(String java, Log log) {
+        return new MavenDevModeLauncher(log).new Builder(java);
+    }
+
+    public class Builder extends QuarkusDevModeLauncher.Builder<MavenDevModeLauncher, Builder> {
+
+        private Builder(String java) {
+            super(java);
+        }
+    }
+
+    private final Log log;
+
+    private MavenDevModeLauncher(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    protected boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    protected void debug(Object msg) {
+        log.error(msg == null ? "null" : msg.toString());
+    }
+
+    @Override
+    protected void error(Object msg) {
+        log.error(msg == null ? "null" : msg.toString());
+    }
+
+    @Override
+    protected void warn(Object msg) {
+        log.warn(msg == null ? "null" : msg.toString());
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/MojoLogger.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/MojoLogger.java
@@ -1,0 +1,198 @@
+package io.quarkus.maven;
+
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.shared.utils.logging.MessageBuilder;
+import org.apache.maven.shared.utils.logging.MessageUtils;
+import org.jboss.logging.Logger;
+import org.jboss.logging.LoggerProvider;
+import org.wildfly.common.Assert;
+
+/**
+ */
+public class MojoLogger implements LoggerProvider {
+    static final Object[] NO_PARAMS = new Object[0];
+
+    public static volatile Log delegate;
+
+    @Override
+    public Logger getLogger(final String name) {
+        return new Logger(name) {
+            @Override
+            protected void doLog(final Level level, final String loggerClassName, final Object message,
+                    final Object[] parameters, final Throwable thrown) {
+                final Log log = delegate;
+                if (log != null) {
+                    String text;
+                    if (parameters == null || parameters.length == 0) {
+                        text = String.valueOf(message);
+                    } else {
+                        try {
+                            text = MessageFormat.format(String.valueOf(message), parameters);
+                        } catch (Exception e) {
+                            text = invalidFormat(String.valueOf(message), parameters);
+                        }
+                    }
+                    synchronized (MojoLogger.class) {
+                        doActualLog(log, level, text, thrown);
+                    }
+                }
+            }
+
+            @Override
+            protected void doLogf(final Level level, final String loggerClassName, final String format,
+                    final Object[] parameters, final Throwable thrown) {
+                final Log log = delegate;
+                if (log != null) {
+                    String text;
+                    if (parameters == null) {
+                        try {
+                            //noinspection RedundantStringFormatCall
+                            text = String.format(format);
+                        } catch (Exception e) {
+                            text = invalidFormat(format, NO_PARAMS);
+                        }
+                    } else {
+                        try {
+                            text = String.format(format, (Object[]) parameters);
+                        } catch (Exception e) {
+                            text = invalidFormat(format, parameters);
+                        }
+                    }
+                    synchronized (MojoLogger.class) {
+                        doActualLog(log, level, text, thrown);
+                    }
+                }
+            }
+
+            @Override
+            public boolean isEnabled(final Level level) {
+                final Log log = delegate;
+                if (log == null)
+                    return false;
+                switch (level) {
+                    case FATAL:
+                    case ERROR:
+                        return log.isErrorEnabled();
+                    case WARN:
+                        return log.isWarnEnabled();
+                    case INFO:
+                        return log.isInfoEnabled();
+                    default:
+                        return log.isDebugEnabled();
+                }
+            }
+
+            void doActualLog(final Log log, final Level level, final String message, final Throwable thrown) {
+                final MessageBuilder buffer = MessageUtils.buffer();
+                // style options are limited unless we crack into jansi ourselves
+                buffer.strong("[").project(name).strong("]").a(" ").a(message);
+                if (thrown != null) {
+                    switch (level) {
+                        case FATAL:
+                        case ERROR:
+                            log.error(buffer.toString(), thrown);
+                            break;
+                        case WARN:
+                            log.warn(buffer.toString(), thrown);
+                            break;
+                        case INFO:
+                            log.info(buffer.toString(), thrown);
+                            break;
+                        default:
+                            log.debug(buffer.toString(), thrown);
+                            break;
+                    }
+                } else {
+                    switch (level) {
+                        case FATAL:
+                        case ERROR:
+                            log.error(buffer.toString());
+                            break;
+                        case WARN:
+                            log.warn(buffer.toString());
+                            break;
+                        case INFO:
+                            log.info(buffer.toString());
+                            break;
+                        default:
+                            log.debug(buffer.toString());
+                            break;
+                    }
+                }
+            }
+        };
+    }
+
+    String invalidFormat(final String format, final Object[] parameters) {
+        final StringBuilder b = new StringBuilder("** invalid format \'" + format + "\'");
+        if (parameters != null && parameters.length > 0) {
+            b.append(" [").append(parameters[0]);
+            for (int i = 1; i < parameters.length; i++) {
+                b.append(',').append(parameters[i]);
+            }
+            b.append("]");
+        }
+        return b.toString();
+    }
+
+    @Override
+    public void clearMdc() {
+    }
+
+    @Override
+    public Object putMdc(final String key, final Object value) {
+        //throw Assert.unsupported();
+        return null;
+    }
+
+    @Override
+    public Object getMdc(final String key) {
+        return null;
+    }
+
+    @Override
+    public void removeMdc(final String key) {
+    }
+
+    @Override
+    public Map<String, Object> getMdcMap() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void clearNdc() {
+    }
+
+    @Override
+    public String getNdc() {
+        return "";
+    }
+
+    @Override
+    public int getNdcDepth() {
+        return 0;
+    }
+
+    @Override
+    public String popNdc() {
+        return "";
+    }
+
+    @Override
+    public String peekNdc() {
+        return "";
+    }
+
+    @Override
+    public void pushNdc(final String message) {
+        throw Assert.unsupported();
+    }
+
+    @Override
+    public void setNdcMaxDepth(final int maxDepth) {
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/PrepareMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/PrepareMojo.java
@@ -1,0 +1,17 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+@Deprecated
+@Mojo(name = "prepare", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class PrepareMojo extends GenerateCodeMojo {
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        getLog().warn("'prepare' goal is deprecated. Please use 'generate-code' instead");
+        super.execute();
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/PrepareTestsMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/PrepareTestsMojo.java
@@ -1,0 +1,17 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+@Deprecated
+@Mojo(name = "prepare-tests", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class PrepareTestsMojo extends GenerateCodeTestsMojo {
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        getLog().warn("'prepare-tests' goal is deprecated. Please use 'generate-code-tests' instead");
+        super.execute();
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusBootstrapMojo.java
@@ -1,0 +1,212 @@
+package io.quarkus.maven;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.runtime.LaunchMode;
+
+public abstract class QuarkusBootstrapMojo extends AbstractMojo {
+
+    @Component
+    protected QuarkusBootstrapProvider bootstrapProvider;
+
+    /**
+     * The current repository/network configuration of Maven.
+     *
+     * @parameter default-value="${repositorySystemSession}"
+     * @readonly
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    private RepositorySystemSession repoSession;
+
+    /**
+     * The project's remote repositories to use for the resolution of artifacts and their dependencies.
+     *
+     * @parameter default-value="${project.remoteProjectRepositories}"
+     * @readonly
+     */
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> repos;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Parameter(defaultValue = "${project.build.directory}")
+    private File buildDir;
+
+    @Parameter(defaultValue = "${project.build.finalName}")
+    private String finalName;
+
+    /**
+     * When building an uber-jar, this array specifies entries that should
+     * be excluded from the final jar. The entries are relative to the root of
+     * the file. An example of this configuration could be:
+     * <code><pre>
+     * &#x3C;configuration&#x3E;
+     *   &#x3C;uberJar&#x3E;true&#x3C;/uberJar&#x3E;
+     *   &#x3C;ignoredEntries&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.SF&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC2048KE.DSA&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.SF&#x3C;/ignoredEntry&#x3E;
+     *     &#x3C;ignoredEntry&#x3E;META-INF/BC1024KE.DSA&#x3C;/ignoredEntry&#x3E;
+     *   &#x3C;/ignoredEntries&#x3E;
+     * &#x3C;/configuration&#x3E;
+     * </pre></code>
+     */
+    @Parameter(property = "ignoredEntries")
+    private String[] ignoredEntries;
+
+    /**
+     * Coordinates of the Maven artifact containing the original Java application to build the native image for.
+     * If not provided, the current project is assumed to be the original Java application.
+     * <p>
+     * The coordinates are expected to be expressed in the following format:
+     * <p>
+     * groupId:artifactId:classifier:type:version
+     * <p>
+     * With the classifier, type and version being optional.
+     * <p>
+     * If the type is missing, the artifact is assumed to be of type JAR.
+     * <p>
+     * If the version is missing, the artifact is going to be looked up among the project dependencies using the provided
+     * coordinates.
+     *
+     * <p>
+     * However, if the expression consists of only three parts, it is assumed to be groupId:artifactId:version.
+     *
+     * <p>
+     * If the expression consists of only four parts, it is assumed to be groupId:artifactId:classifier:type.
+     */
+    @Parameter(required = false, property = "appArtifact")
+    private String appArtifact;
+
+    /**
+     * The properties of the plugin.
+     */
+    @Parameter(property = "properties", required = false)
+    private Map<String, String> properties = new HashMap<>();
+
+    /**
+     * The context of the execution of the plugin.
+     */
+    @Parameter(defaultValue = "${mojoExecution}", readonly = true, required = true)
+    private MojoExecution mojoExecution;
+
+    private ArtifactKey projectId;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!beforeExecute()) {
+            return;
+        }
+        doExecute();
+    }
+
+    @Override
+    public void setLog(Log log) {
+        super.setLog(log);
+        MojoLogger.delegate = log;
+    }
+
+    /**
+     * This callback allows to evaluate whether this mojo should be executed, skipped or fail.
+     *
+     * @return false if the execution of the mojo should be skipped, true if the mojo should be executed
+     * @throws MojoExecutionException in case of a failure
+     * @throws MojoFailureException in case of a failure
+     */
+    protected abstract boolean beforeExecute() throws MojoExecutionException, MojoFailureException;
+
+    /**
+     * Main mojo execution code
+     *
+     * @throws MojoExecutionException in case of a failure
+     * @throws MojoFailureException in case of a failure
+     */
+    protected abstract void doExecute() throws MojoExecutionException, MojoFailureException;
+
+    protected String appArtifactCoords() {
+        return appArtifact;
+    }
+
+    protected RepositorySystem repositorySystem() {
+        return bootstrapProvider.repositorySystem();
+    }
+
+    protected RemoteRepositoryManager remoteRepositoryManager() {
+        return bootstrapProvider.remoteRepositoryManager();
+    }
+
+    protected RepositorySystemSession repositorySystemSession() {
+        return repoSession;
+    }
+
+    protected List<RemoteRepository> remoteRepositories() {
+        return repos;
+    }
+
+    protected MavenProject mavenProject() {
+        return project;
+    }
+
+    public MavenSession mavenSession() {
+        return session;
+    }
+
+    protected File buildDir() {
+        return buildDir;
+    }
+
+    protected File baseDir() {
+        return project.getBasedir();
+    }
+
+    protected String finalName() {
+        return finalName;
+    }
+
+    protected String[] ignoredEntries() {
+        return ignoredEntries;
+    }
+
+    protected Map<String, String> properties() {
+        return properties;
+    }
+
+    protected String executionId() {
+        return mojoExecution.getExecutionId();
+    }
+
+    protected ArtifactKey projectId() {
+        return projectId == null ? projectId = QuarkusBootstrapProvider.getProjectId(project) : projectId;
+    }
+
+    protected CuratedApplication bootstrapApplication() throws MojoExecutionException {
+        return bootstrapApplication(LaunchMode.NORMAL);
+    }
+
+    protected CuratedApplication bootstrapApplication(LaunchMode mode) throws MojoExecutionException {
+        return bootstrapProvider.bootstrapApplication(this, mode);
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusBootstrapProvider.java
@@ -1,0 +1,310 @@
+package io.quarkus.maven;
+
+import static io.smallrye.common.expression.Expression.Flag.LENIENT_SYNTAX;
+import static io.smallrye.common.expression.Expression.Flag.NO_TRIM;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import io.quarkus.bootstrap.BootstrapException;
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.resolver.AppModelResolverException;
+import io.quarkus.bootstrap.resolver.BootstrapAppModelResolver;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
+import io.quarkus.maven.dependency.GACT;
+import io.quarkus.maven.dependency.GACTV;
+import io.quarkus.maven.dependency.ResolvedArtifactDependency;
+import io.quarkus.runtime.LaunchMode;
+import io.smallrye.common.expression.Expression;
+
+@Component(role = QuarkusBootstrapProvider.class, instantiationStrategy = "singleton")
+public class QuarkusBootstrapProvider implements Closeable {
+
+    @Requirement(role = RepositorySystem.class, optional = false)
+    protected RepositorySystem repoSystem;
+
+    @Requirement(role = RemoteRepositoryManager.class, optional = false)
+    protected RemoteRepositoryManager remoteRepoManager;
+
+    private final Cache<String, QuarkusAppBootstrapProvider> appBootstrapProviders = CacheBuilder.newBuilder()
+            .concurrencyLevel(4).softValues().initialCapacity(10).build();
+
+    static ArtifactKey getProjectId(MavenProject project) {
+        return new GACT(project.getGroupId(), project.getArtifactId());
+    }
+
+    public RepositorySystem repositorySystem() {
+        return repoSystem;
+    }
+
+    public RemoteRepositoryManager remoteRepositoryManager() {
+        return remoteRepoManager;
+    }
+
+    private QuarkusAppBootstrapProvider provider(ArtifactKey projectId, String executionId) {
+        try {
+            return appBootstrapProviders.get(String.format("%s-%s", projectId, executionId), QuarkusAppBootstrapProvider::new);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed to cache a new instance of " + QuarkusAppBootstrapProvider.class.getName(),
+                    e);
+        }
+    }
+
+    public CuratedApplication bootstrapApplication(QuarkusBootstrapMojo mojo, LaunchMode mode)
+            throws MojoExecutionException {
+        return provider(mojo.projectId(), mojo.executionId()).bootstrapApplication(mojo, mode);
+    }
+
+    public ApplicationModel getResolvedApplicationModel(ArtifactKey projectId, LaunchMode mode) {
+        if (appBootstrapProviders.size() == 0) {
+            return null;
+        }
+        final QuarkusAppBootstrapProvider provider = appBootstrapProviders.getIfPresent(projectId + "-null");
+        if (provider == null) {
+            return null;
+        }
+        if (mode == LaunchMode.DEVELOPMENT) {
+            return provider.devApp == null ? null : provider.devApp.getApplicationModel();
+        }
+        if (mode == LaunchMode.TEST) {
+            return provider.testApp == null ? null : provider.testApp.getApplicationModel();
+        }
+        return provider.prodApp == null ? null : provider.prodApp.getApplicationModel();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (appBootstrapProviders.size() == 0) {
+            return;
+        }
+        for (QuarkusAppBootstrapProvider p : appBootstrapProviders.asMap().values()) {
+            try {
+                p.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private class QuarkusAppBootstrapProvider implements Closeable {
+
+        private CuratedApplication prodApp;
+        private CuratedApplication devApp;
+        private CuratedApplication testApp;
+
+        private MavenArtifactResolver artifactResolver(QuarkusBootstrapMojo mojo, LaunchMode mode)
+                throws MojoExecutionException {
+            try {
+                return MavenArtifactResolver.builder()
+                        .setWorkspaceDiscovery(mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST)
+                        .setPreferPomsFromWorkspace(mode == LaunchMode.DEVELOPMENT || mode == LaunchMode.TEST)
+                        .setRepositorySystem(repoSystem)
+                        .setRepositorySystemSession(mojo.repositorySystemSession())
+                        .setRemoteRepositories(mojo.remoteRepositories())
+                        .setRemoteRepositoryManager(remoteRepoManager)
+                        .build();
+            } catch (BootstrapMavenException e) {
+                throw new MojoExecutionException("Failed to initialize Quarkus bootstrap Maven artifact resolver", e);
+            }
+        }
+
+        protected CuratedApplication doBootstrap(QuarkusBootstrapMojo mojo, LaunchMode mode)
+                throws MojoExecutionException {
+            final Properties projectProperties = mojo.mavenProject().getProperties();
+            final Properties effectiveProperties = new Properties();
+            // quarkus. properties > ignoredEntries in pom.xml
+            if (mojo.ignoredEntries() != null && mojo.ignoredEntries().length > 0) {
+                String joinedEntries = String.join(",", mojo.ignoredEntries());
+                effectiveProperties.setProperty("quarkus.package.user-configured-ignored-entries", joinedEntries);
+            }
+            for (String name : projectProperties.stringPropertyNames()) {
+                if (name.startsWith("quarkus.")) {
+                    effectiveProperties.setProperty(name, projectProperties.getProperty(name));
+                }
+            }
+
+            // Add plugin properties
+            effectiveProperties.putAll(mojo.properties());
+
+            effectiveProperties.putIfAbsent("quarkus.application.name", mojo.mavenProject().getArtifactId());
+            effectiveProperties.putIfAbsent("quarkus.application.version", mojo.mavenProject().getVersion());
+
+            // Add other properties that may be required for expansion
+            for (Object value : effectiveProperties.values()) {
+                for (String reference : Expression.compile((String) value, LENIENT_SYNTAX, NO_TRIM).getReferencedStrings()) {
+                    String referenceValue = mojo.mavenSession().getUserProperties().getProperty(reference);
+                    if (referenceValue != null) {
+                        effectiveProperties.setProperty(reference, referenceValue);
+                        continue;
+                    }
+
+                    referenceValue = projectProperties.getProperty(reference);
+                    if (referenceValue != null) {
+                        effectiveProperties.setProperty(reference, referenceValue);
+                    }
+                }
+            }
+
+            final BootstrapAppModelResolver modelResolver = new BootstrapAppModelResolver(artifactResolver(mojo, mode))
+                    .setDevMode(mode == LaunchMode.DEVELOPMENT)
+                    .setTest(mode == LaunchMode.TEST);
+
+            final List<MavenProject> localProjects = mojo.mavenProject().getCollectedProjects();
+            final Set<ArtifactKey> reloadableModules = new HashSet<>(localProjects.size() + 1);
+            final ArtifactCoords artifactCoords = appArtifact(mojo);
+            reloadableModules.add(new GACT(artifactCoords.getGroupId(), artifactCoords.getArtifactId()));
+            for (MavenProject project : localProjects) {
+                reloadableModules.add(new GACT(project.getGroupId(), project.getArtifactId()));
+            }
+
+            final ApplicationModel appModel;
+            try {
+                appModel = modelResolver.resolveManagedModel(artifactCoords, Collections.emptyList(), managingProject(mojo),
+                        reloadableModules);
+            } catch (AppModelResolverException e) {
+                throw new MojoExecutionException("Failed to bootstrap application in " + mode + " mode", e);
+            }
+
+            QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder()
+                    .setAppArtifact(appModel.getAppArtifact())
+                    .setExistingModel(appModel)
+                    .setIsolateDeployment(true)
+                    .setBaseClassLoader(getClass().getClassLoader())
+                    .setBuildSystemProperties(effectiveProperties)
+                    .setProjectRoot(mojo.baseDir().toPath())
+                    .setBaseName(mojo.finalName())
+                    .setTargetDirectory(mojo.buildDir().toPath());
+
+            try {
+                return builder.build().bootstrap();
+            } catch (BootstrapException e) {
+                throw new MojoExecutionException("Failed to bootstrap the application", e);
+            }
+        }
+
+        protected CuratedApplication bootstrapApplication(QuarkusBootstrapMojo mojo, LaunchMode mode)
+                throws MojoExecutionException {
+            if (mode == LaunchMode.DEVELOPMENT) {
+                return devApp == null ? devApp = doBootstrap(mojo, mode) : devApp;
+            }
+            if (mode == LaunchMode.TEST) {
+                return testApp == null ? testApp = doBootstrap(mojo, mode) : testApp;
+            }
+            return prodApp == null ? prodApp = doBootstrap(mojo, mode) : prodApp;
+        }
+
+        protected GACTV managingProject(QuarkusBootstrapMojo mojo) {
+            if (mojo.appArtifactCoords() == null) {
+                return null;
+            }
+            final Artifact artifact = mojo.mavenProject().getArtifact();
+            return new GACTV(artifact.getGroupId(), artifact.getArtifactId(),
+                    artifact.getClassifier(), artifact.getArtifactHandler().getExtension(),
+                    artifact.getVersion());
+        }
+
+        private ArtifactCoords appArtifact(QuarkusBootstrapMojo mojo)
+                throws MojoExecutionException {
+            String appArtifactCoords = mojo.appArtifactCoords();
+            if (appArtifactCoords == null) {
+                final Artifact projectArtifact = mojo.mavenProject().getArtifact();
+
+                File projectFile = projectArtifact.getFile();
+                if (projectFile == null) {
+                    projectFile = new File(mojo.mavenProject().getBuild().getOutputDirectory());
+                    if (!projectFile.exists()) {
+                        /*
+                         * TODO GenerateCodeMojo would fail
+                         * if (hasSources(project)) {
+                         * throw new MojoExecutionException("Project " + project.getArtifact() + " has not been compiled yet");
+                         * }
+                         */
+                        if (!projectFile.mkdirs()) {
+                            throw new MojoExecutionException("Failed to create the output dir " + projectFile);
+                        }
+                    }
+                }
+                return new ResolvedArtifactDependency(projectArtifact.getGroupId(), projectArtifact.getArtifactId(),
+                        projectArtifact.getClassifier(), projectArtifact.getArtifactHandler().getExtension(),
+                        projectArtifact.getVersion(), projectFile.toPath());
+            }
+
+            final String[] coordsArr = appArtifactCoords.split(":");
+            if (coordsArr.length < 2 || coordsArr.length > 5) {
+                throw new MojoExecutionException(
+                        "appArtifact expression " + appArtifactCoords
+                                + " does not follow format groupId:artifactId:classifier:type:version");
+            }
+            final String groupId = coordsArr[0];
+            final String artifactId = coordsArr[1];
+            String classifier = "";
+            String type = GACTV.TYPE_JAR;
+            String version = null;
+            if (coordsArr.length == 3) {
+                version = coordsArr[2];
+            } else if (coordsArr.length > 3) {
+                classifier = coordsArr[2] == null ? "" : coordsArr[2];
+                type = coordsArr[3] == null ? "jar" : coordsArr[3];
+                if (coordsArr.length > 4) {
+                    version = coordsArr[4];
+                }
+            }
+            if (version == null) {
+                for (Artifact dep : mojo.mavenProject().getArtifacts()) {
+                    if (dep.getArtifactId().equals(artifactId)
+                            && dep.getGroupId().equals(groupId)
+                            && dep.getClassifier().equals(classifier)
+                            && dep.getType().equals(type)) {
+                        version = dep.getVersion();
+                        break;
+                    }
+                }
+                if (version == null) {
+                    throw new IllegalStateException(
+                            "Failed to locate " + appArtifactCoords + " among the project dependencies");
+                }
+            }
+
+            return new GACTV(groupId, artifactId, classifier, type, version);
+        }
+
+        @Override
+        public void close() {
+            if (prodApp != null) {
+                prodApp.close();
+                prodApp = null;
+            }
+            if (devApp != null) {
+                devApp.close();
+                devApp = null;
+            }
+            if (testApp != null) {
+                testApp.close();
+                testApp = null;
+            }
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusMavenWorkspaceBuilder.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusMavenWorkspaceBuilder.java
@@ -1,0 +1,52 @@
+package io.quarkus.maven;
+
+import java.io.File;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Resource;
+import org.apache.maven.project.MavenProject;
+
+import io.quarkus.bootstrap.model.ApplicationModelBuilder;
+import io.quarkus.bootstrap.workspace.DefaultProcessedSources;
+import io.quarkus.bootstrap.workspace.DefaultWorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.bootstrap.workspace.WorkspaceModuleId;
+import io.quarkus.maven.dependency.GAV;
+import io.quarkus.paths.PathList;
+
+class QuarkusMavenWorkspaceBuilder {
+
+    static void loadModules(MavenProject project, ApplicationModelBuilder modelBuilder) {
+    }
+
+    static WorkspaceModule toProjectModule(MavenProject project) {
+        final Build build = project.getBuild();
+        final DefaultWorkspaceModule module = new DefaultWorkspaceModule(getId(project), project.getBasedir(),
+                new File(build.getDirectory()));
+
+        final File classesDir = new File(build.getOutputDirectory());
+        project.getCompileSourceRoots()
+                .forEach(s -> module.addMainSources(new DefaultProcessedSources(new File(s), classesDir)));
+        final File testClassesDir = new File(build.getTestOutputDirectory());
+        project.getTestCompileSourceRoots()
+                .forEach(s -> module.addTestSources(new DefaultProcessedSources(new File(s), testClassesDir)));
+
+        for (Resource r : build.getResources()) {
+            module.addMainResources(new DefaultProcessedSources(new File(r.getDirectory()),
+                    r.getTargetPath() == null ? classesDir : new File(r.getTargetPath())));
+        }
+
+        for (Resource r : build.getTestResources()) {
+            module.addTestResources(new DefaultProcessedSources(new File(r.getDirectory()),
+                    r.getTargetPath() == null ? testClassesDir : new File(r.getTargetPath())));
+        }
+
+        module.setBuildFiles(PathList.of(project.getFile().toPath()));
+
+        return module;
+    }
+
+    private static WorkspaceModuleId getId(MavenProject project) {
+        return new GAV(project.getGroupId(), project.getArtifactId(), project.getVersion());
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/QuarkusProjectMojoBase.java
@@ -1,0 +1,285 @@
+package io.quarkus.maven;
+
+import static io.quarkus.devtools.project.CodestartResourceLoadersBuilder.getCodestartResourceLoaders;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+
+import io.quarkus.bootstrap.BootstrapConstants;
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.BuildTool;
+import io.quarkus.devtools.project.QuarkusProject;
+import io.quarkus.devtools.project.QuarkusProjectHelper;
+import io.quarkus.devtools.project.buildfile.MavenProjectBuildFile;
+import io.quarkus.maven.utilities.MojoUtils;
+import io.quarkus.platform.descriptor.loader.json.ResourceLoader;
+import io.quarkus.platform.tools.ToolsConstants;
+import io.quarkus.platform.tools.ToolsUtils;
+import io.quarkus.platform.tools.maven.MojoMessageWriter;
+import io.quarkus.registry.ExtensionCatalogResolver;
+import io.quarkus.registry.RegistryResolutionException;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import io.quarkus.registry.catalog.Platform;
+import io.quarkus.registry.catalog.PlatformCatalog;
+import io.quarkus.registry.catalog.PlatformRelease;
+import io.quarkus.registry.catalog.PlatformStream;
+
+public abstract class QuarkusProjectMojoBase extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}")
+    protected MavenProject project;
+
+    @Component
+    protected RepositorySystem repoSystem;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true)
+    protected RepositorySystemSession repoSession;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    protected List<RemoteRepository> repos;
+
+    @Parameter(property = "bomGroupId", required = false)
+    private String bomGroupId;
+
+    @Parameter(property = "bomArtifactId", required = false)
+    private String bomArtifactId;
+
+    @Parameter(property = "bomVersion", required = false)
+    private String bomVersion;
+
+    @Component
+    RemoteRepositoryManager remoteRepositoryManager;
+
+    private List<ArtifactCoords> importedPlatforms;
+
+    private Artifact projectArtifact;
+    private MavenArtifactResolver artifactResolver;
+    private ExtensionCatalogResolver catalogResolver;
+    private MessageWriter log;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+
+        // Validate Mojo parameters
+        validateParameters();
+
+        final Path projectDirPath = baseDir();
+        BuildTool buildTool = QuarkusProject.resolveExistingProjectBuildTool(projectDirPath);
+        if (buildTool == null) {
+            // it's not Gradle and the pom.xml not found, so we assume there is not project at all
+            buildTool = BuildTool.MAVEN;
+        }
+
+        final QuarkusProject quarkusProject;
+        if (BuildTool.MAVEN.equals(buildTool) && project.getFile() != null) {
+            try {
+                quarkusProject = MavenProjectBuildFile.getProject(projectArtifact(), project.getOriginalModel(), baseDir(),
+                        project.getModel().getProperties(), artifactResolver(), getMessageWriter(), null);
+            } catch (RegistryResolutionException e) {
+                throw new MojoExecutionException("Failed to initialize Quarkus Maven extension manager", e);
+            }
+        } else {
+            final List<ResourceLoader> codestartsResourceLoader = getCodestartResourceLoaders(resolveExtensionCatalog());
+            quarkusProject = QuarkusProject.of(baseDir(), resolveExtensionCatalog(),
+                    codestartsResourceLoader,
+                    log, buildTool);
+        }
+
+        doExecute(quarkusProject, getMessageWriter());
+    }
+
+    protected MessageWriter getMessageWriter() {
+        return log == null ? log = new MojoMessageWriter(getLog()) : log;
+    }
+
+    protected Path baseDir() {
+        return project == null || project.getBasedir() == null ? Paths.get("").normalize().toAbsolutePath()
+                : project.getBasedir().toPath();
+    }
+
+    private ExtensionCatalog resolveExtensionCatalog() throws MojoExecutionException {
+        final ExtensionCatalogResolver catalogResolver = QuarkusProjectHelper.isRegistryClientEnabled()
+                ? getExtensionCatalogResolver()
+                : ExtensionCatalogResolver.empty();
+        if (catalogResolver.hasRegistries()) {
+            try {
+                return catalogResolver.resolveExtensionCatalog(getImportedPlatforms());
+            } catch (Exception e) {
+                throw new MojoExecutionException("Failed to resolve the Quarkus extension catalog", e);
+            }
+        }
+        return ToolsUtils.mergePlatforms(collectImportedPlatforms(), artifactResolver());
+    }
+
+    protected ExtensionCatalogResolver getExtensionCatalogResolver() throws MojoExecutionException {
+        if (catalogResolver == null) {
+            try {
+                catalogResolver = QuarkusProjectHelper.getCatalogResolver(artifactResolver(), getMessageWriter());
+            } catch (RegistryResolutionException e) {
+                throw new MojoExecutionException("Failed to initialize Quarkus extension resolver", e);
+            }
+        }
+        return catalogResolver;
+    }
+
+    protected List<ArtifactCoords> getImportedPlatforms() throws MojoExecutionException {
+        if (importedPlatforms == null) {
+            if (project.getFile() == null) {
+                if (bomGroupId == null && bomArtifactId == null && bomVersion == null) {
+                    return Collections.emptyList();
+                }
+                if (bomGroupId == null) {
+                    bomGroupId = ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID;
+                }
+                ArtifactCoords platformBom = null;
+                try {
+                    platformBom = getSingleMatchingBom(bomGroupId, bomArtifactId, bomVersion,
+                            getExtensionCatalogResolver().resolvePlatformCatalog());
+                } catch (RegistryResolutionException e) {
+                    throw new MojoExecutionException("Failed to resolve the catalog of Quarkus platforms", e);
+                }
+                return importedPlatforms = Collections.singletonList(platformBom);
+            }
+            importedPlatforms = collectImportedPlatforms();
+        }
+        return importedPlatforms;
+    }
+
+    private MavenArtifactResolver artifactResolver() throws MojoExecutionException {
+        if (artifactResolver == null) {
+            try {
+                artifactResolver = MavenArtifactResolver.builder()
+                        .setRepositorySystem(repoSystem)
+                        .setRepositorySystemSession(
+                                getLog().isDebugEnabled() ? repoSession : MojoUtils.muteTransferListener(repoSession))
+                        .setRemoteRepositories(repos)
+                        .setRemoteRepositoryManager(remoteRepositoryManager)
+                        .build();
+            } catch (BootstrapMavenException e) {
+                throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);
+            }
+        }
+        return artifactResolver;
+    }
+
+    private List<ArtifactCoords> collectImportedPlatforms()
+            throws MojoExecutionException {
+        final List<ArtifactCoords> descriptors = new ArrayList<>(4);
+        final List<Dependency> constraints = project.getDependencyManagement() == null ? Collections.emptyList()
+                : project.getDependencyManagement().getDependencies();
+        if (!constraints.isEmpty()) {
+            final MessageWriter log = getMessageWriter();
+            for (Dependency d : constraints) {
+                if (!("json".equals(d.getType())
+                        && d.getArtifactId().endsWith(BootstrapConstants.PLATFORM_DESCRIPTOR_ARTIFACT_ID_SUFFIX))) {
+                    continue;
+                }
+                final ArtifactCoords a = new ArtifactCoords(d.getGroupId(), d.getArtifactId(), d.getClassifier(),
+                        d.getType(), d.getVersion());
+                descriptors.add(a);
+                log.debug("Found platform descriptor %s", a);
+            }
+        }
+        return descriptors;
+    }
+
+    private String getQuarkusCoreVersion() {
+        final List<Dependency> constraints = project.getDependencyManagement() == null ? Collections.emptyList()
+                : project.getDependencyManagement().getDependencies();
+        for (Dependency d : constraints) {
+            if (d.getArtifactId().endsWith("quarkus-core") && d.getGroupId().equals("io.quarkus")) {
+                return d.getVersion();
+            }
+        }
+        return null;
+    }
+
+    protected void validateParameters() throws MojoExecutionException {
+    }
+
+    protected abstract void doExecute(QuarkusProject quarkusProject, MessageWriter log)
+            throws MojoExecutionException;
+
+    private Artifact projectArtifact() {
+        return projectArtifact == null
+                ? projectArtifact = new DefaultArtifact(project.getGroupId(), project.getArtifactId(), null, "pom",
+                        project.getVersion())
+                : projectArtifact;
+    }
+
+    static ArtifactCoords getSingleMatchingBom(String bomGroupId, String bomArtifactId, String bomVersion,
+            PlatformCatalog platformCatalog) throws MojoExecutionException {
+        if (bomGroupId == null && bomArtifactId == null && bomVersion == null) {
+            return null;
+        }
+        if (bomGroupId == null) {
+            bomGroupId = ToolsConstants.DEFAULT_PLATFORM_BOM_GROUP_ID;
+        }
+        ArtifactCoords platformBom = null;
+        List<ArtifactCoords> matches = null;
+        for (Platform p : platformCatalog.getPlatforms()) {
+            if (!p.getPlatformKey().equals(bomGroupId)) {
+                continue;
+            }
+            for (PlatformStream s : p.getStreams()) {
+                for (PlatformRelease r : s.getReleases()) {
+                    for (ArtifactCoords bom : r.getMemberBoms()) {
+                        if (bomArtifactId != null && !bom.getArtifactId().equals(bomArtifactId)) {
+                            continue;
+                        }
+                        if (bomVersion != null && !bom.getVersion().equals(bomVersion)) {
+                            continue;
+                        }
+                        if (platformBom == null) {
+                            platformBom = bom;
+                        } else {
+                            if (matches == null) {
+                                matches = new ArrayList<>();
+                                matches.add(platformBom);
+                            }
+                            matches.add(bom);
+                        }
+                    }
+                }
+            }
+        }
+        if (matches != null) {
+            StringWriter buf = new StringWriter();
+            buf.append("Multiple platforms were matching the requested platform BOM coordinates ");
+            buf.append(bomGroupId == null ? "*" : bomGroupId).append(':');
+            buf.append(bomArtifactId == null ? "*" : bomArtifactId).append(':');
+            buf.append(bomVersion == null ? "*" : bomVersion).append(": ");
+            try (BufferedWriter writer = new BufferedWriter(buf)) {
+                for (ArtifactCoords bom : matches) {
+                    writer.newLine();
+                    writer.append("- ").append(bom.toString());
+                }
+            } catch (IOException e) {
+                //
+            }
+            throw new MojoExecutionException(buf.toString());
+        }
+        return platformBom;
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/RemoteDevMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/RemoteDevMojo.java
@@ -1,0 +1,16 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * The dev mojo, that connects to a remote host.
+ */
+@Mojo(name = "remote-dev", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST)
+public class RemoteDevMojo extends DevMojo {
+    @Override
+    protected void modifyDevModeContext(MavenDevModeLauncher.Builder builder) {
+        builder.remoteDev(true);
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/RemoveExtensionMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/RemoveExtensionMojo.java
@@ -1,0 +1,70 @@
+package io.quarkus.maven;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import io.quarkus.devtools.commands.RemoveExtensions;
+import io.quarkus.devtools.commands.data.QuarkusCommandOutcome;
+import io.quarkus.devtools.messagewriter.MessageWriter;
+import io.quarkus.devtools.project.QuarkusProject;
+
+/**
+ * Allow removing an extension from an existing pom.xml file.
+ * Because you can remove one or several extension in one go, there are 2 mojos:
+ * {@code remove-extensions} and {@code remove-extension}. Both supports the {@code extension} and {@code extensions}
+ * parameters.
+ */
+@Mojo(name = "remove-extension")
+public class RemoveExtensionMojo extends QuarkusProjectMojoBase {
+
+    /**
+     * The list of extensions to be removed.
+     */
+    @Parameter(property = "extensions")
+    Set<String> extensions;
+
+    /**
+     * For usability reason, this parameter allow removing a single extension.
+     */
+    @Parameter(property = "extension")
+    String extension;
+
+    @Override
+    protected void validateParameters() throws MojoExecutionException {
+        if ((StringUtils.isBlank(extension) && (extensions == null || extensions.isEmpty())) // None are set
+                || (!StringUtils.isBlank(extension) && extensions != null && !extensions.isEmpty())) { // Both are set
+            throw new MojoExecutionException("Either the `extension` or `extensions` parameter must be set");
+        }
+    }
+
+    @Override
+    public void doExecute(final QuarkusProject quarkusProject, final MessageWriter log) throws MojoExecutionException {
+
+        Set<String> ext = new HashSet<>();
+        if (extensions != null && !extensions.isEmpty()) {
+            ext.addAll(extensions);
+        } else {
+            // Parse the "extension" just in case it contains several comma-separated values
+            // https://github.com/quarkusio/quarkus/issues/2393
+            ext.addAll(Arrays.stream(extension.split(",")).map(s -> s.trim()).collect(Collectors.toSet()));
+        }
+
+        try {
+            final QuarkusCommandOutcome outcome = new RemoveExtensions(quarkusProject)
+                    .extensions(ext.stream().map(String::trim).collect(Collectors.toSet()))
+                    .execute();
+            if (!outcome.isSuccess()) {
+                throw new MojoExecutionException("Unable to remove extensions");
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("Unable to update the pom.xml file", e);
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/RemoveExtensionsMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/RemoveExtensionsMojo.java
@@ -1,0 +1,14 @@
+package io.quarkus.maven;
+
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Allow removing extensions to an existing pom.xml file.
+ * Because you can remove one or several extension in one go, there are 2 mojos:
+ * {@code remove-extensions} and {@code remove-extension}. Both supports the {@code extension} and {@code extensions}
+ * parameters.
+ */
+@Mojo(name = "remove-extensions")
+public class RemoveExtensionsMojo extends RemoveExtensionMojo {
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/TestMojo.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/TestMojo.java
@@ -1,0 +1,28 @@
+package io.quarkus.maven;
+
+import java.util.function.Consumer;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.deployment.dev.DevModeContext;
+import io.quarkus.deployment.dev.IsolatedTestModeMain;
+
+/**
+ * The test mojo, that starts continuous testing outside of dev mode
+ */
+@Mojo(name = "test", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST)
+public class TestMojo extends DevMojo {
+    @Override
+    protected void modifyDevModeContext(MavenDevModeLauncher.Builder builder) {
+        builder.entryPointCustomizer(new Consumer<DevModeContext>() {
+            @Override
+            public void accept(DevModeContext devModeContext) {
+                devModeContext.setMode(QuarkusBootstrap.Mode.CONTINUOUS_TEST);
+                devModeContext.setAlternateEntryPoint(IsolatedTestModeMain.class.getName());
+            }
+        });
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/components/BootstrapSessionListener.java
@@ -1,0 +1,27 @@
+package io.quarkus.maven.components;
+
+import java.io.IOException;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+
+import io.quarkus.maven.QuarkusBootstrapProvider;
+
+@Component(role = AbstractMavenLifecycleParticipant.class, hint = "quarkus-bootstrap")
+public class BootstrapSessionListener extends AbstractMavenLifecycleParticipant {
+
+    @Requirement(optional = false)
+    protected QuarkusBootstrapProvider bootstrapProvider;
+
+    @Override
+    public void afterSessionEnd(MavenSession session) throws MavenExecutionException {
+        try {
+            bootstrapProvider.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/components/MavenVersionEnforcer.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/components/MavenVersionEnforcer.java
@@ -1,0 +1,114 @@
+package io.quarkus.maven.components;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.versioning.*;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.component.annotations.Component;
+
+@Component(role = MavenVersionEnforcer.class, instantiationStrategy = "per-lookup")
+public class MavenVersionEnforcer {
+
+    public void ensureMavenVersion(Log log, MavenSession session) throws MojoExecutionException {
+        final String supported;
+        try {
+            supported = getSupportedMavenVersions();
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to ensure Quarkus Maven version compatibility", e);
+        }
+        String mavenVersion = session.getSystemProperties().getProperty("maven.version");
+        if (log.isDebugEnabled()) {
+            log.debug("Detected Maven Version: " + mavenVersion);
+        }
+        DefaultArtifactVersion detectedVersion = new DefaultArtifactVersion(mavenVersion);
+        enforce(log, supported, detectedVersion);
+    }
+
+    private static String getSupportedMavenVersions() throws IOException {
+        return loadQuarkusProperties().getProperty("supported-maven-versions");
+    }
+
+    private static Properties loadQuarkusProperties() throws IOException {
+        final String resource = "quarkus.properties";
+        final InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        if (is == null) {
+            throw new IOException("Could not locate " + resource + " on the classpath");
+        }
+        final Properties props = new Properties();
+        try {
+            props.load(is);
+        } catch (IOException e) {
+            throw new IOException("Failed to load " + resource + " from the classpath", e);
+        }
+        return props;
+    }
+
+    /**
+     * Compares the specified Maven version to see if it is allowed by the defined version range.
+     *
+     * @param log the log
+     * @param requiredMavenVersionRange range of allowed versions for Maven.
+     * @param actualMavenVersion the version to be checked.
+     * @throws MojoExecutionException the given version fails the enforcement rule
+     */
+    private void enforce(Log log,
+            String requiredMavenVersionRange, ArtifactVersion actualMavenVersion)
+            throws MojoExecutionException {
+        if (StringUtils.isBlank(requiredMavenVersionRange)) {
+            throw new MojoExecutionException("Maven version can't be empty.");
+        }
+        if (!actualMavenVersion.toString().equals(requiredMavenVersionRange)) {
+            try {
+                final VersionRange vr = VersionRange.createFromVersionSpec(requiredMavenVersionRange);
+                if (!containsVersion(vr, actualMavenVersion)) {
+                    throw new MojoExecutionException(getDetectedVersionStr(actualMavenVersion.toString())
+                            + " is not supported, it must be in " + vr + ".");
+                }
+            } catch (InvalidVersionSpecificationException e) {
+                throw new MojoExecutionException("The requested Maven version "
+                        + requiredMavenVersionRange + " is invalid.", e);
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    getDetectedVersionStr(actualMavenVersion.toString()) + " is allowed in " + requiredMavenVersionRange + ".");
+        }
+    }
+
+    /**
+     * Copied from Artifact.VersionRange. This is tweaked to handle singular ranges properly. Currently the default
+     * containsVersion method assumes a singular version means allow everything.
+     *
+     * @param allowedRange range of allowed versions.
+     * @param theVersion the version to be checked.
+     * @return {@code true} if the version is contained by the range.
+     */
+    private static boolean containsVersion(VersionRange allowedRange, ArtifactVersion theVersion) {
+        boolean matched = false;
+        ArtifactVersion recommendedVersion = allowedRange.getRecommendedVersion();
+        if (recommendedVersion == null) {
+            List<Restriction> restrictions = allowedRange.getRestrictions();
+            for (Restriction restriction : restrictions) {
+                if (restriction.containsVersion(theVersion)) {
+                    matched = true;
+                    break;
+                }
+            }
+        } else {
+            // only singular versions ever have a recommendedVersion
+            int compareTo = recommendedVersion.compareTo(theVersion);
+            matched = (compareTo <= 0);
+        }
+        return matched;
+    }
+
+    private static String getDetectedVersionStr(String version) {
+        return "Detected Maven Version (" + version + ") ";
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/components/Prompter.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/maven/components/Prompter.java
@@ -1,0 +1,72 @@
+package io.quarkus.maven.components;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.aesh.readline.Readline;
+import org.aesh.readline.ReadlineBuilder;
+import org.aesh.readline.tty.terminal.TerminalConnection;
+
+/**
+ * Prompt implementation.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class Prompter {
+
+    private static class Prompt {
+        private final String prompt;
+        private final String defaultValue;
+        private final Consumer<String> inputConsumer;
+
+        public Prompt(String prompt, String defaultValue, Consumer<String> inputConsumer) {
+            this.prompt = prompt;
+            this.defaultValue = defaultValue;
+            this.inputConsumer = inputConsumer;
+        }
+    }
+
+    private final List<Prompt> prompts = new ArrayList<>();
+
+    public Prompter() throws IOException {
+    }
+
+    public Prompter addPrompt(String prompt, Consumer<String> inputConsumer) {
+        prompts.add(new Prompt(prompt, null, inputConsumer));
+        return this;
+    }
+
+    public Prompter addPrompt(String prompt, String defaultValue, Consumer<String> inputConsumer) {
+        prompts.add(new Prompt(prompt, defaultValue, inputConsumer));
+        return this;
+    }
+
+    public void collectInput() throws IOException {
+        if (prompts.isEmpty()) {
+            return;
+        }
+        final TerminalConnection connection = new TerminalConnection();
+        try {
+            read(connection, ReadlineBuilder.builder().enableHistory(false).build(), prompts.iterator());
+            connection.openBlocking();
+        } finally {
+            connection.close();
+        }
+    }
+
+    private static void read(TerminalConnection connection, Readline readline, Iterator<Prompt> prompts) {
+        final Prompt prompt = prompts.next();
+        readline.readline(connection, prompt.prompt, input -> {
+            prompt.inputConsumer.accept(
+                    (input == null || input.isBlank()) && prompt.defaultValue != null ? prompt.defaultValue : input);
+            if (!prompts.hasNext()) {
+                connection.close();
+            } else {
+                read(connection, readline, prompts);
+            }
+        });
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/platform/tools/maven/MojoMessageWriter.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/java/io/quarkus/platform/tools/maven/MojoMessageWriter.java
@@ -1,0 +1,39 @@
+package io.quarkus.platform.tools.maven;
+
+import org.apache.maven.plugin.logging.Log;
+
+import io.quarkus.devtools.messagewriter.MessageWriter;
+
+public class MojoMessageWriter implements MessageWriter {
+
+    private final Log log;
+
+    public MojoMessageWriter(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    public void info(String msg) {
+        log.info(msg);
+    }
+
+    @Override
+    public void error(String msg) {
+        log.error(msg);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(String msg) {
+        log.debug(msg);
+    }
+
+    @Override
+    public void warn(String msg) {
+        log.warn(msg);
+    }
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/INDEX.LIST
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/INDEX.LIST
@@ -1,0 +1,18 @@
+JarIndex-Version: 1.0
+
+quarkus-maven-plugin-2.5.0.Final-sources.jar
+META-INF
+META-INF/m2e
+META-INF/maven
+META-INF/maven/io.quarkus
+META-INF/maven/io.quarkus/quarkus-maven-plugin
+META-INF/services
+create-extension-templates
+io
+io/quarkus
+io/quarkus/maven
+io/quarkus/maven/components
+io/quarkus/platform
+io/quarkus/platform/tools
+io/quarkus/platform/tools/maven
+

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/MANIFEST.MF
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,22 @@
+Manifest-Version: 1.0
+Created-By: Maven Archiver 3.4.0
+Build-Jdk-Spec: 11
+Specification-Title: Quarkus - Maven Plugin
+Specification-Version: 2.5
+Specification-Vendor: JBoss by Red Hat
+Implementation-Title: Quarkus - Maven Plugin
+Implementation-Version: 2.5.0.Final
+Implementation-Vendor: JBoss by Red Hat
+Implementation-URL: https://github.com/quarkusio/quarkus/quarkus-build-p
+ arent/quarkus-maven-plugin
+Java-Vendor: AdoptOpenJDK
+Java-Version: 11.0.11
+Os-Arch: amd64
+Os-Name: Linux
+Os-Version: 5.12.17-200.fc33.x86_64
+Scm-Connection: scm:git:git@github.com:quarkusio/quarkus.git/quarkus-bui
+ ld-parent/quarkus-maven-plugin
+Scm-Revision: 9bbe5d242d291e76b6ccb6567d6b836945bf12dd
+Scm-Url: https://github.com/quarkusio/quarkus/quarkus-build-parent/quark
+ us-maven-plugin
+

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,18 @@
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>generate-code</goal>
+                    <goal>generate-code-tests</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <runOnIncremental>false</runOnIncremental>
+                    <runOnConfiguration>true</runOnConfiguration>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/services/org.jboss.logging.LoggerProvider
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/META-INF/services/org.jboss.logging.LoggerProvider
@@ -1,0 +1,1 @@
+io.quarkus.maven.MojoLogger

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/DevModeTest.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/DevModeTest.java
@@ -1,0 +1,22 @@
+package [=javaPackageBase].test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class [=artifactIdBaseCamelCase]DevModeTest {
+    @RegisterExtension
+    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest() // Start hot reload (DevMode) test with your extension loaded
+        .withEmptyApplication();
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-hot-reload for more information
+        Assertions.fail("Add dev mode assertions to " + getClass().getName());
+    }
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/IT.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/IT.java
@@ -1,0 +1,8 @@
+package [=javaPackageBase].it;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+class [=artifactIdBaseCamelCase]IT extends [=artifactIdBaseCamelCase]Test {
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/Processor.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/Processor.java
@@ -1,0 +1,15 @@
+package [=javaPackageBase].deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+class [=artifactIdBaseCamelCase]Processor {
+
+    private static final String FEATURE = "[=artifactIdBase]";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/Test.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/Test.java
@@ -1,0 +1,17 @@
+package [=javaPackageBase].it;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+class [=artifactIdBaseCamelCase]Test {
+
+    @Test
+    public void test() {
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/TestResource.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/TestResource.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package [=javaPackageBase].it;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.Path;
+
+@Path("/[=artifactIdBase]")
+@ApplicationScoped
+public class [=artifactIdBaseCamelCase]Resource {
+
+    // add some rest methods here
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/UnitTest.java
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/UnitTest.java
@@ -1,0 +1,23 @@
+package [=javaPackageBase].test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class [=artifactIdBaseCamelCase]Test {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest() // Start unit test with your extension loaded
+        .withEmptyApplication();
+
+    @Test
+    public void test() {
+        // Write your tests here - see the testing extension guide https://quarkus.io/guides/writing-extensions#testing-extensions for more information
+        Assertions.fail("Add some assertions to " + getClass().getName());
+    }
+
+}

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/deployment-pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/deployment-pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>[=groupId]</groupId>
+        <artifactId>[=artifactId]-parent</artifactId>
+        <version>[=version]</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>[=artifactId]-deployment</artifactId>
+[#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Deployment</name>
+[/#if]
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>[=groupId]</groupId>
+            <artifactId>[=artifactId]</artifactId>
+[#if !assumeManaged ]            <version>[=r"$"]{project.version}</version>
+[/#if]
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>[=quarkusVersion]</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/integration-test-pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/integration-test-pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+[#if itestParentGroupId?? ]    <parent>
+        <groupId>[=itestParentGroupId]</groupId>
+        <artifactId>[=itestParentArtifactId]</artifactId>
+        <version>[=itestParentVersion]</version>
+        <relativePath>[=itestParentRelativePath]</relativePath>
+    </parent>
+[/#if]
+
+    <artifactId>[=artifactId]-integration-test</artifactId>
+[#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Integration Test</name>
+[/#if]
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+[#if !assumeManaged ]            <version>[=quarkusVersion]</version>
+[/#if]
+        </dependency>
+        <dependency>
+            <groupId>[=groupId]</groupId>
+            <artifactId>[=artifactId]</artifactId>
+[#if !assumeManaged ]            <version>[=r"$"]{project.version}</version>
+[/#if]
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+[#if !assumeManaged ]            <version>[=quarkusVersion]</version>
+[/#if]
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+[#if !assumeManaged ]            <version>[=r"$"]{rest-assured.version}</version>
+[/#if]
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${native.surefire.skip}</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <maven.home>${maven.home}</maven.home>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/parent-pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/parent-pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+[#if grandParentGroupId?? ]    <parent>
+        <groupId>[=grandParentGroupId]</groupId>
+        <artifactId>[=grandParentArtifactId]</artifactId>
+        <version>[=grandParentVersion]</version>
+[#if grandParentRelativePath?? ]        <relativePath>[=grandParentRelativePath]</relativePath>
+[/#if]
+    </parent>
+[/#if]
+
+[#if grandParentGroupId?? ][#if groupId != grandParentGroupId ]    <groupId>[=groupId]</groupId>
+[/#if][#else ]    <groupId>[=groupId]</groupId>
+[/#if]
+    <artifactId>[=artifactId]-parent</artifactId>
+[#if groupId?? && (!grandParentGroupId?? || groupId != grandParentGroupId) && version?? && (!grandParentVersion?? || version != grandParentVersion) ]    <version>[=version]</version>
+[/#if]
+[#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Parent</name>
+[/#if]
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
+    </properties>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/runtime-pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/src/main/resources/create-extension-templates/runtime-pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>[=groupId]</groupId>
+        <artifactId>[=artifactId]-parent</artifactId>
+        <version>[=version]</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>[=artifactId]</artifactId>
+[#if nameBase?? ]    <name>[=namePrefix][=nameBase][=nameSegmentDelimiter]Runtime</name>
+[/#if]
+
+    <dependencies>
+[#if additionalRuntimeDependencies?size > 0 ]
+[#list additionalRuntimeDependencies as dep]
+        <dependency>
+            <groupId>[=dep.groupId]</groupId>
+            <artifactId>[=dep.artifactId]</artifactId>
+[#if !bomPathSet ]            <version>[=dep.version]</version>
+[/#if]
+[#if dep.type?? ]            <type>[=dep.type]</type>
+[/#if]
+[#if dep.classifier?? ]            <type>[=dep.classifier]</type>
+[/#if]
+[#if dep.scope?? ]            <type>[=dep.scope]</type>
+[/#if]
+        </dependency>
+[/#list]
+[/#if]
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+[#if !assumeManaged ]                <version>[=quarkusVersion]</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <deployment>[=r"$"]{project.groupId}:[=r"$"]{project.artifactId}-deployment:[=r"$"]{project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+[/#if]
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>[=quarkusVersion]</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
@@ -67,7 +71,7 @@
 
         <quarkus-google-cloud-services.version>0.10.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.37</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.39</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>


### PR DESCRIPTION
With this upgrade instead simply re-publishing the original `io.quarkus:quarkus-maven-plugin` binary as `io.quarkus.platform:quarkus-maven-plugin`, the sources of the `io.quarkus:quarkus-maven-plugin` obtained from its `sources` JAR will be imported into the platform project and the platform Maven plugin will be re-built from them.

This solves a couple of issues:
1) it will automatically provide the sources JAR to the platform Maven plugin (previously missing);
2) re-generate the platform Maven plugin metadata the way it should be done (and will include the currently missing goal descriptions, as can be seeing by running `quarkus:help`).

Switching to re-publishing the binaries can be done by adding this config
````
                            <importSources>false</importSources>
                        </attachedMavenPlugin>
                    </platformConfig>
````