### PR TITLE
remove invalid redhat-support values.

### DIFF
--- a/src/main/resources/core/extensions-support-overrides.json
+++ b/src/main/resources/core/extensions-support-overrides.json
@@ -884,15 +884,6 @@
     },
     {
       "group-id": "io.quarkus",
-      "artifact-id": "quarkus-jacoco",
-      "metadata": {
-        "redhat-support": [
-          "unsupported"
-        ]
-      }
-    },
-    {
-      "group-id": "io.quarkus",
       "artifact-id": "quarkus-websockets",
       "metadata": {
         "redhat-support": [


### PR DESCRIPTION
redhat-support is to signal support, unsupported is done by NOT having any redhat-support entry.