### PR TITLE
Upgrade to the platform generator 0.0.42

### DIFF
--- a/generated-platform-project/quarkus-kogito/bom/pom.xml
+++ b/generated-platform-project/quarkus-kogito/bom/pom.xml
@@ -1796,12 +1796,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-decisions-spring-boot-starter</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-dmn</artifactId>
         <version>1.14.0.Final</version>
       </dependency>
@@ -1980,12 +1974,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-processes-spring-boot-starter</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-common</artifactId>
         <version>1.14.0.Final</version>
       </dependency>
@@ -2157,12 +2145,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-rules-spring-boot-starter</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-ruleunits</artifactId>
         <version>1.14.0.Final</version>
       </dependency>
@@ -2244,12 +2226,6 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-services</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-spring-boot-starter</artifactId>
         <version>1.14.0.Final</version>
         <classifier>sources</classifier>
       </dependency>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -19222,12 +19222,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-decisions-spring-boot-starter</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-dmn</artifactId>
         <version>1.14.0.Final</version>
       </dependency>
@@ -19406,12 +19400,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-processes-spring-boot-starter</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-common</artifactId>
         <version>1.14.0.Final</version>
       </dependency>
@@ -19583,12 +19571,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-rules-spring-boot-starter</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-ruleunits</artifactId>
         <version>1.14.0.Final</version>
       </dependency>
@@ -19670,12 +19652,6 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-services</artifactId>
-        <version>1.14.0.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-spring-boot-starter</artifactId>
         <version>1.14.0.Final</version>
         <classifier>sources</classifier>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,8 @@
 
         <quarkus-google-cloud-services.version>0.11.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.41</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.42</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
-        <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>
 
@@ -123,11 +122,6 @@
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         </systemProperties>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.gmaven</groupId>
-                    <artifactId>groovy-maven-plugin</artifactId>
-                    <version>${groovy-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -455,10 +449,10 @@
                                 <dependency>io.quarkus:quarkus-bom-quarkus-platform-properties::properties</dependency>
                                 <dependency>com.oracle.instantclient:xstreams</dependency> <!-- provided dependency of a Debezium extension, supposed to be added by users manually -->
                                 <!-- Kogito: exclude Spring-related dependencies -->
-                                <dependency>org.kie.kogito:kogito-spring-boot-starter</dependency>
-                                <dependency>org.kie.kogito:kogito-decisions-spring-boot-starter</dependency>
-                                <dependency>org.kie.kogito:kogito-processes-spring-boot-starter</dependency>
-                                <dependency>org.kie.kogito:kogito-rules-spring-boot-starter</dependency>
+                                <dependency>org.kie.kogito:kogito-spring-boot-starter:*</dependency>
+                                <dependency>org.kie.kogito:kogito-decisions-spring-boot-starter:*</dependency>
+                                <dependency>org.kie.kogito:kogito-processes-spring-boot-starter:*</dependency>
+                                <dependency>org.kie.kogito:kogito-rules-spring-boot-starter:*</dependency>
                             </excludedDependencies>
                         </bomGenerator>
                         <descriptorGenerator>


### PR DESCRIPTION
This version includes a couple of features:

* support for excluding artifacts with any classifier by specifying `groupId:artifactId:*`
* log a report of common extension dependencies that aren't managed by the BOMs (enabled by adding `-DlogCommonNotManagedDeps` to the command line)