### PR TITLE
Upgrade to the platform generator 0.0.42

### DIFF
--- a/generated-platform-project/quarkus-kogito/bom/pom.xml
+++ b/generated-platform-project/quarkus-kogito/bom/pom.xml
@@ -1171,12 +1171,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-decisions-spring-boot-starter</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-dmn</artifactId>
         <version>1.11.1.Final</version>
       </dependency>
@@ -1317,12 +1311,6 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-predictions-spring-boot-starter</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-processes-spring-boot-starter</artifactId>
         <version>1.11.1.Final</version>
         <classifier>sources</classifier>
       </dependency>
@@ -1499,12 +1487,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-rules-spring-boot-starter</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-ruleunits</artifactId>
         <version>1.11.1.Final</version>
       </dependency>
@@ -1586,12 +1568,6 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-services</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-spring-boot-starter</artifactId>
         <version>1.11.1.Final</version>
         <classifier>sources</classifier>
       </dependency>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -18014,12 +18014,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-decisions-spring-boot-starter</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-dmn</artifactId>
         <version>1.11.1.Final</version>
       </dependency>
@@ -18160,12 +18154,6 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-predictions-spring-boot-starter</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-processes-spring-boot-starter</artifactId>
         <version>1.11.1.Final</version>
         <classifier>sources</classifier>
       </dependency>
@@ -18342,12 +18330,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-rules-spring-boot-starter</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-ruleunits</artifactId>
         <version>1.11.1.Final</version>
       </dependency>
@@ -18429,12 +18411,6 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-services</artifactId>
-        <version>1.11.1.Final</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-spring-boot-starter</artifactId>
         <version>1.11.1.Final</version>
         <classifier>sources</classifier>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
         <quarkus-google-cloud-services.version>0.10.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.41</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.42</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
@@ -463,10 +463,10 @@
                                 <dependency>io.quarkus:quarkus-bom-quarkus-platform-properties::properties</dependency>
                                 <dependency>com.oracle.instantclient:xstreams</dependency> <!-- provided dependency of a Debezium extension, supposed to be added by users manually -->
                                 <!-- Kogito: exclude Spring-related dependencies -->
-                                <dependency>org.kie.kogito:kogito-spring-boot-starter</dependency>
-                                <dependency>org.kie.kogito:kogito-decisions-spring-boot-starter</dependency>
-                                <dependency>org.kie.kogito:kogito-processes-spring-boot-starter</dependency>
-                                <dependency>org.kie.kogito:kogito-rules-spring-boot-starter</dependency>
+                                <dependency>org.kie.kogito:kogito-spring-boot-starter:*</dependency>
+                                <dependency>org.kie.kogito:kogito-decisions-spring-boot-starter:*</dependency>
+                                <dependency>org.kie.kogito:kogito-processes-spring-boot-starter:*</dependency>
+                                <dependency>org.kie.kogito:kogito-rules-spring-boot-starter:*</dependency>
                             </excludedDependencies>
                         </bomGenerator>
                         <descriptorGenerator>


### PR DESCRIPTION
This version includes a couple of features:

* support for excluding artifacts with any classifier by specifying `groupId:artifactId:*`
* log a report of common extension dependencies that aren't managed by the BOMs (enabled by adding `-DlogCommonNotManagedDeps` to the command line)