### PR TITLE
Upgrade to the platform generator 0.0.45

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
         <quarkus-google-cloud-services.version>0.10.0</quarkus-google-cloud-services.version>
 
-        <quarkus-platform-bom-generator.version>0.0.42</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.45</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>


### PR DESCRIPTION
This upgrade allows to specify exclusions in the dependencyManagement configuration. E.g.

<dependencyManagement>
    <dependencySpec>
        <artifact>io.playground:playground-stuff:1.0</artifact>
        <exclusions>
            <exclusion>org.acme:acme-stuff</exclusion>
        </exclusions>
    </dependencySpec>
</dependencyManagement>