### PR TITLE
Disable Camel HTTP tests

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-http</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-http</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -166,6 +169,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-http:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -17,6 +17,7 @@
     <module>camel-quarkus-integration-test-sjms-qpid-amqp-client</module>
     <module>camel-quarkus-integration-test-sjms2-qpid-amqp-client</module>
     <module>camel-quarkus-integration-test-csimple</module>
+    <module>camel-quarkus-integration-test-http</module>
     <module>camel-quarkus-integration-test-main-unknown-args-ignore</module>
     <module>camel-quarkus-integration-test-syslog</module>
     <module>camel-quarkus-integration-test-telegram</module>
@@ -77,7 +78,6 @@
     <module>camel-quarkus-integration-test-hazelcast</module>
     <module>camel-quarkus-integration-test-headersmap</module>
     <module>camel-quarkus-integration-test-hl7</module>
-    <module>camel-quarkus-integration-test-http</module>
     <module>camel-quarkus-integration-test-hystrix</module>
     <module>camel-quarkus-integration-test-infinispan</module>
     <module>camel-quarkus-integration-test-influxdb</module>

--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,10 @@
                                         <skip>true</skip>
                                         <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-csimple:${camel-quarkus.version}</artifact>
                                     </test>
+                                    <test><!-- Workaround for http tests failing with Quarkus 999-SNAPSHOT and CQ 2.6.0  -->
+                                        <skip>true</skip>
+                                        <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-http:${camel-quarkus.version}</artifact>
+                                    </test>
                                     <test><!-- Workaround for https://github.com/apache/camel-quarkus/pull/3055 -->
                                         <skip>true</skip>
                                         <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-unknown-args-ignore:${camel-quarkus.version}</artifact>


### PR DESCRIPTION
Should hopefully fix the remaining Camel failure on the nightly SNAPSHOT build.