### PR TITLE
Update to Quarkus Qpid JMS 0.33.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -791,12 +791,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -6545,7 +6545,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tinkerpop</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.5.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -10331,12 +10331,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.31.0</version>
+        <version>0.32.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -16400,7 +16400,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.3.0</version>
+        <version>1.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tinkerpop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>1.0.2</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.0.1</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>0.31.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.32.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>2.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.6.1.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.5</quarkus-blaze-persistence.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.33.0, uses Qpid JMS 1.5.0 against Quarkus 2.7.0.Final