### PR TITLE
Use quarkus-hazelcast-client:3.0.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -447,22 +447,22 @@
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
-        <version>4.2</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-hazelcast-client-deployment</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-hazelcast-client</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-test-hazelcast</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>

--- a/generated-platform-project/quarkus-hazelcast/bom/pom.xml
+++ b/generated-platform-project/quarkus-hazelcast/bom/pom.xml
@@ -61,22 +61,22 @@
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
-        <version>4.2</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-hazelcast-client-deployment</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-hazelcast-client</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-test-hazelcast</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>javax.cache</groupId>

--- a/generated-platform-project/quarkus-hazelcast/integration-tests/quarkus-hazelcast-client-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-hazelcast/integration-tests/quarkus-hazelcast-client-integration-tests/pom.xml
@@ -26,11 +26,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-test-artemis</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jackson</artifactId>
       <scope>test</scope>
     </dependency>
@@ -51,6 +46,10 @@
         <exclusion>
           <groupId>javax.activation</groupId>
           <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.sun.xml.bind</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -3113,22 +3113,22 @@
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
-        <version>4.2</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-hazelcast-client-deployment</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-hazelcast-client</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>quarkus-test-hazelcast</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.ibm.db2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <quarkus-amazon-services.version>1.0.4</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.0.1</quarkus-config-consul.version>
         <quarkus-qpid-jms.version>0.32.0</quarkus-qpid-jms.version>
-        <quarkus-hazelcast-client.version>2.0.0</quarkus-hazelcast-client.version>
+        <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.6.1.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.6</quarkus-blaze-persistence.version>
         <quarkus-cassandra-client.version>1.1.1</quarkus-cassandra-client.version>


### PR DESCRIPTION
Adding new major version of Hazelcast Client extension which uses Hazelcast 5.0.2 and Quarkus 2.7.2 as baseline.