### PR TITLE
Upgrade to platform generator 0.0.48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <quarkus-google-cloud-services.version>1.0.0</quarkus-google-cloud-services.version>
         <quarkus-vault.version>1.0.2</quarkus-vault.version>
 
-        <quarkus-platform-bom-generator.version>0.0.46</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.48</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>


### PR DESCRIPTION
The platform generator was upgraded to Quarkus 2.8.0.Final, which required refactoring in the descriptor generating plugin.
The generator also was partly refactored towards supporting alignment of common but not managed extension dependencies.