### PR TITLE
Configure Cassandra's own groupIds

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -284,22 +284,12 @@
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
         <version>4.14.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/generated-platform-project/quarkus-cassandra/bom/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/bom/pom.xml
@@ -96,10 +96,6 @@
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -126,12 +122,6 @@
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
         <version>4.14.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -364,10 +364,6 @@
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -394,12 +390,6 @@
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
         <version>4.14.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <quarkus-google-cloud-services.version>1.0.0</quarkus-google-cloud-services.version>
         <quarkus-vault.version>1.1.0</quarkus-vault.version>
 
-        <quarkus-platform-bom-generator.version>0.0.48</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.49</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>
@@ -338,6 +338,10 @@
                             <member>
                                 <name>Cassandra</name>
                                 <bom>com.datastax.oss.quarkus:cassandra-quarkus-bom:${quarkus-cassandra-client.version}</bom>
+                                <ownGroupIds>
+                                    <groupId>com.datastax.oss</groupId>
+                                    <groupId>com.datastax.oss.quarkus</groupId>
+                                </ownGroupIds>
                                 <enabled>true</enabled>
                                 <release>
                                     <lastDetectedBomUpdate>io.quarkus.platform:quarkus-cassandra-bom:2.8.0.CR1</lastDetectedBomUpdate>


### PR DESCRIPTION
@ppalaga I wanted to discuss this with you. Here I am configuring groupIds that belong to Cassandra and that other members aren't allowed to override versions for.
The way it works currently, it takes the complete dependency element from the Cassandra BOM and replicates everywhere, including the Camel BOM. Which is why you see the exclusions being removed in from the Camel BOM. In fact, I can preserve inclusions in the Camel BOM but it seems like none of the approaches will be always right. I think the current behavior has more chances to be right in the majority of cases.