### PR TITLE
Add camel-quarkus-test-list.version property

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-solr/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-solr/pom.xml
@@ -136,12 +136,12 @@
           <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-support</artifactId>
-            <version>${camel-quarkus.version}</version>
+            <version>${camel-quarkus-test-list.version}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-integration-test-solr</artifactId>
-            <version>${camel-quarkus.version}</version>
+            <version>${camel-quarkus-test-list.version}</version>
             <classifier>tests</classifier>
           </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <quarkus-bom.version>${quarkus.version}</quarkus-bom.version>
 
         <camel-quarkus.version>2.10.0</camel-quarkus.version>
+        <camel-quarkus-test-list.version>${camel-quarkus.version}</camel-quarkus-test-list.version>
 
         <!-- If you made changes to the integration tests pom of Amazon Services,
              make sure you have a look at the AmazonServices member section below
@@ -405,27 +406,27 @@
                                         </nativeSystemProperties>
                                         <transformWith>${resourcesdir}/xslt/camel/test-pom.xsl</transformWith>
                                     </defaultTestConfig>
-                                    <testCatalogArtifact>org.apache.camel.quarkus:camel-quarkus-test-list::xml:${camel-quarkus.version}</testCatalogArtifact>
+                                    <testCatalogArtifact>org.apache.camel.quarkus:camel-quarkus-test-list::xml:${camel-quarkus-test-list.version}</testCatalogArtifact>
                                     <tests>
                                         <test><!-- Workaround for weird issue with shared networking & keycloak container -->
                                             <skip>true</skip>
-                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-oauth:${camel-quarkus.version}</artifact>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-oauth:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                         <test><!-- Workaround flaky file test https://github.com/apache/camel-quarkus/issues/3627 -->
                                             <skip>true</skip>
-                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-file:${camel-quarkus.version}</artifact>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-file:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                         <test><!-- Workaround incompatible PostgreSQL JDBC driver -->
                                             <skip>true</skip>
-                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-debezium:${camel-quarkus.version}</artifact>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-debezium:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                         <test><!-- Workaround for Quarkus 999-SNAPSHOT & CQ <= 2.10.x Vert.x incompatibility -->
                                             <skip>true</skip>
-                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http:${camel-quarkus.version}</artifact>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                         <test><!-- Workaround for Quarkus 999-SNAPSHOT & CQ <= 2.10.x Vert.x incompatibility -->
                                             <skip>true</skip>
-                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-rest:${camel-quarkus.version}</artifact>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-rest:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                     </tests>
                                 </member>

--- a/src/main/resources/xslt/camel/test-pom.xsl
+++ b/src/main/resources/xslt/camel/test-pom.xsl
@@ -77,12 +77,12 @@
                         <dependency>
                             <groupId>org.apache.camel.quarkus</groupId>
                             <artifactId>camel-quarkus-integration-test-support</artifactId>
-                            <version>${camel-quarkus.version}</version>
+                            <version>${camel-quarkus-test-list.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>org.apache.camel.quarkus</groupId>
                             <artifactId>camel-quarkus-integration-test-solr</artifactId>
-                            <version>${camel-quarkus.version}</version>
+                            <version>${camel-quarkus-test-list.version}</version>
                             <classifier>tests</classifier>
                         </dependency>
                     </dependencies>


### PR DESCRIPTION
This allows to control the test list artifact version using a separate property.