### PR TITLE
Exclude MS SQL and Oracle JDBC dependencies from dependencies to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -821,12 +821,14 @@
                                         <groupId>org.testcontainers</groupId>
                                         <groupId>org.junit.jupiter</groupId>
                                         <groupId>org.junit.platform</groupId>
+                                        <!-- https://issues.redhat.com/browse/QUARKUS-1164 -->
+                                        <groupId>com.oracle.database.jdbc</groupId>
                                     </excludeGroupIds>
-                                    <!-- exclude dependencies specifying their keys
                                     <excludeKeys>
-                                        <key>org.testcontainers:db2</key>
+                                        <!-- https://issues.redhat.com/browse/QUARKUS-1304 -->
+                                        <key>com.microsoft.sqlserver:mssql-jdbc</key>
+                                        <key>com.microsoft.azure:adal4j</key>
                                     </excludeKeys>
-                                    -->
                                     <!-- exclude specific versions of dependencies
                                     <excludeArtifacts>
                                         <artifact>org.testcontainers:database-commons:1.17.2</artifact>


### PR DESCRIPTION
Exclude MS SQL and Oracle JDBC dependencies from dependencies to build

Oracle has just `com.oracle.database.jdbc:ojdbc11`

MS SQL has more deps:
```
[INFO] |  +- com.microsoft.sqlserver:mssql-jdbc:jar:7.2.2.jre8:compile
[INFO] |  \- com.microsoft.azure:adal4j:jar:1.6.7.redhat-00001:compile
[INFO] |     \- com.nimbusds:oauth2-oidc-sdk:jar:9.4.0.redhat-00001:compile
[INFO] |        \- com.nimbusds:content-type:jar:2.1:compile
```

CC @aloubyansky 