### PR TITLE
Vault 2.0.0-RC1

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -6305,17 +6305,17 @@
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>1.1.0</version>
+        <version>2.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-model</artifactId>
-        <version>1.1.0</version>
+        <version>2.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>1.1.0</version>
+        <version>2.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -2863,17 +2863,17 @@
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>1.1.0</version>
+        <version>2.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-model</artifactId>
-        <version>1.1.0</version>
+        <version>2.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>1.1.0</version>
+        <version>2.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <optaplanner-quarkus.version>8.25.0.Final</optaplanner-quarkus.version>
 
         <quarkus-google-cloud-services.version>1.2.0</quarkus-google-cloud-services.version>
-        <quarkus-vault.version>1.1.0</quarkus-vault.version>
+        <quarkus-vault.version>2.0.0-RC1</quarkus-vault.version>
 
         <quarkus-platform-bom-generator.version>0.0.57</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
cc @aloubyansky 
@kdubb I see in https://github.com/quarkusio/quarkus/wiki/Release-Planning that `2.12.0 CR1` is tomorrow, and final will be on the 24th, so we must release Vault `2.0.0` before then, and re-update the platform.