### PR TITLE
Update to Quarkus Qpid JMS 0.37.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -888,12 +888,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.36.0</version>
+        <version>0.37.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.36.0</version>
+        <version>0.37.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.36.0</version>
+        <version>0.37.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.36.0</version>
+        <version>0.37.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -11372,12 +11372,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.36.0</version>
+        <version>0.37.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.36.0</version>
+        <version>0.37.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>1.1.3</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.1.0</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>0.36.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.37.0</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.9.5.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.7</quarkus-blaze-persistence.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.37.0, uses Qpid JMS 1.6.0 against Quarkus 2.12.0.Final