### PR TITLE
Upgrade Quarkus to 2.7.7.Final and revert Camel Quarkus to 2.7.1

### DIFF
--- a/generated-platform-project/quarkus-amazon-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/bom/pom.xml
@@ -212,12 +212,6 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>apache-client</artifactId>
         <version>2.17.121</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -279,12 +279,22 @@
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-query-builder</artifactId>
         <version>4.13.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
@@ -738,6 +748,12 @@
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
         <version>0.32.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_2.0_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -10526,21 +10542,61 @@
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-quarkus-deployment</artifactId>
         <version>8.17.0.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-quarkus-jackson-deployment</artifactId>
         <version>8.17.0.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-quarkus-jackson</artifactId>
         <version>8.17.0.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-quarkus</artifactId>
         <version>8.17.0.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>
@@ -10622,6 +10678,12 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>apache-client</artifactId>
         <version>2.17.121</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -60,50 +60,12 @@
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-base</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-client</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir-server</artifactId>
         <version>4.1.0</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -121,37 +83,6 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-structures-dstu3</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
           </exclusion>
@@ -165,174 +96,6 @@
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-structures-r4</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-structures-r5</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.dstu2</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.dstu3</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.r4</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.r5</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.utilities</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -594,11 +357,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.github.mwiede</groupId>
-        <artifactId>jsch</artifactId>
-        <version>0.2.1</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
         <version>2.7.1</version>
@@ -637,6 +395,16 @@
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
         <version>2.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.jcraft</groupId>
+        <artifactId>jzlib</artifactId>
+        <version>1.1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.mchange</groupId>
+        <artifactId>c3p0</artifactId>
+        <version>0.9.5.5</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
@@ -699,7 +467,7 @@
       <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>jakarta.mail</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -720,7 +488,7 @@
       <dependency>
         <groupId>com.zendesk</groupId>
         <artifactId>mysql-binlog-connector-java</artifactId>
-        <version>0.25.4</version>
+        <version>0.25.1</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -799,6 +567,36 @@
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
         <version>1.8.1.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-log4j-appender</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-file</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
@@ -806,6 +604,30 @@
         <version>1.8.1.Final</version>
         <classifier>tests</classifier>
         <exclusions>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-log4j-appender</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-file</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
@@ -941,3387 +763,3387 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc-ws-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc-ws</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atlasmap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atlasmap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atmos-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atmos</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atomix-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atomix</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-rpc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-rpc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanstalk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanstalk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-lrucache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-lrucache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-catalog</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cmis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cmis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-corda-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-corda</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dozer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dozer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elsql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elsql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-facebook-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-facebook</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ganglia-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ganglia</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hbase-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hbase</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hdfs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hdfs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hystrix-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hystrix</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iota-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iota</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ipfs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ipfs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jbpm-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jbpm</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jclouds-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jclouds</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jing-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jing</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-johnzon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-johnzon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-reify-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-reify</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-client</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-metrics-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-metrics</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milo-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milo</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-msv-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-msv</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nagios-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nagios</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nsq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nsq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentracing-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentracing</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-component</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rabbitmq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rabbitmq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ribbon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ribbon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sip-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sip</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soroush-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soroush</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-beans</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-context</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-core</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-stax-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-stax</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xstream-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xstream</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tagsoup-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tagsoup</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vm-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vm</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weka-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weka</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xstream-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xstream</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yammer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yammer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-activemq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4352,7 +4174,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ahc-ws</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4367,7 +4189,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ahc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4390,7 +4212,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -4421,7 +4243,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4436,7 +4258,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-arangodb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4451,12 +4273,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4483,7 +4305,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asn1</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4498,7 +4320,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asterisk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -4517,7 +4339,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atlasmap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4536,7 +4358,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atmos</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4559,7 +4381,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atom</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4582,7 +4404,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atomix</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4597,7 +4419,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -4616,7 +4438,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro-rpc-spi</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>javax.annotation</groupId>
@@ -4631,7 +4453,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro-rpc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4654,7 +4476,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -4677,7 +4499,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4696,7 +4518,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-xray</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4715,7 +4537,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-athena</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4738,7 +4560,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4761,7 +4583,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4784,7 +4606,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ec2</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4807,7 +4629,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ecs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4830,7 +4652,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eks</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4853,7 +4675,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eventbridge</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4876,7 +4698,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-iam</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4899,7 +4721,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4922,7 +4744,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4945,7 +4767,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4968,7 +4790,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-mq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4991,7 +4813,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-msk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5014,7 +4836,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5037,7 +4859,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ses</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5060,7 +4882,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5083,7 +4905,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5106,7 +4928,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sts</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5129,7 +4951,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-translate</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5152,7 +4974,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-cosmosdb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5167,7 +4989,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -5186,7 +5008,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -5205,7 +5027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5220,7 +5042,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -5239,7 +5061,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-barcode</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5254,12 +5076,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base64</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5274,7 +5096,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5289,7 +5111,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5308,7 +5130,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5323,7 +5145,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5338,7 +5160,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanstalk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5353,7 +5175,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5368,7 +5190,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bonita</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5391,12 +5213,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5415,7 +5237,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-braintree</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5430,7 +5252,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5445,7 +5267,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine-lrucache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5460,7 +5282,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5475,7 +5297,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5494,7 +5316,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5509,7 +5331,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cbor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5524,7 +5346,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chatscript</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5539,7 +5361,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chunk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5554,7 +5376,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5569,12 +5391,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cm-sms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5597,7 +5419,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cmis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>asm</groupId>
@@ -5624,7 +5446,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-coap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5639,7 +5461,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cometd</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5658,7 +5480,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5673,7 +5495,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-consul</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5696,7 +5518,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5711,7 +5533,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-corda</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5750,7 +5572,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5765,7 +5587,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5780,7 +5602,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5795,12 +5617,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5815,12 +5637,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchbase</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5835,7 +5657,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchdb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5854,7 +5676,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5869,7 +5691,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5884,7 +5706,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-csv</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5899,7 +5721,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5914,7 +5736,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5937,7 +5759,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mongodb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5964,7 +5786,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mysql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5991,7 +5813,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-postgres</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6018,7 +5840,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-sqlserver</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6045,7 +5867,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-digitalocean</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6064,7 +5886,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6079,7 +5901,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-disruptor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6094,7 +5916,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6109,7 +5931,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dns</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6124,7 +5946,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dozer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6147,7 +5969,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-drill</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6170,7 +5992,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dropbox</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6185,12 +6007,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ehcache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6205,7 +6027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6224,7 +6046,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elsql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6239,7 +6061,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6254,7 +6076,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd3</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6269,7 +6091,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6284,7 +6106,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-exec</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6299,7 +6121,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-facebook</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6314,7 +6136,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fastjson</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6329,12 +6151,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6361,7 +6183,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file-watch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6376,7 +6198,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6391,7 +6213,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flatpack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6406,7 +6228,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6425,7 +6247,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fop</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6444,7 +6266,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-freemarker</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6459,7 +6281,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6474,7 +6296,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ganglia</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6489,7 +6311,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-geocoder</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6512,7 +6334,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-git</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6527,7 +6349,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-github</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6542,7 +6364,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6577,7 +6399,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-calendar</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6600,7 +6422,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-drive</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6623,7 +6445,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-functions</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6650,7 +6472,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-mail</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6673,7 +6495,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6716,7 +6538,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-sheets</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6739,7 +6561,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-storage</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6774,7 +6596,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6793,7 +6615,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grok</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6808,12 +6630,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6828,7 +6650,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6843,7 +6665,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6866,7 +6688,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6881,7 +6703,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-guava-eventbus</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6896,7 +6718,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hazelcast</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6911,7 +6733,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hbase</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6942,7 +6764,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hdfs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6985,7 +6807,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-headersmap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -7008,12 +6830,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7028,12 +6850,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7048,7 +6870,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7071,12 +6893,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-smn</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7091,7 +6913,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hystrix</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7110,7 +6932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ical</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7129,7 +6951,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iec60870</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -7148,7 +6970,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ignite</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7163,18 +6985,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>3.14.4</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7190,22 +7006,14 @@
           </exclusion>
           <exclusion>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-jboss-marshalling</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-marshaller-protostuff</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jgroups</groupId>
-            <artifactId>jgroups</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-influxdb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7220,7 +7028,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iota</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7239,12 +7047,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ipfs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-irc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7259,7 +7067,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7274,7 +7082,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7289,7 +7097,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7304,7 +7112,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7319,7 +7127,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7334,7 +7142,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7349,7 +7157,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7364,7 +7172,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbpm</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7391,7 +7199,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7406,7 +7214,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jclouds</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -7433,7 +7241,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcr</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7452,7 +7260,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7475,7 +7283,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7490,7 +7298,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups-raft</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7505,7 +7313,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7520,7 +7328,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jing</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7535,7 +7343,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7586,7 +7394,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7621,7 +7429,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-johnzon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7636,7 +7444,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jolt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7655,7 +7463,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jooq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>javax.activation</groupId>
@@ -7682,7 +7490,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7697,7 +7505,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7728,7 +7536,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-js-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7743,7 +7551,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7758,7 +7566,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7773,7 +7581,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-patch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7788,7 +7596,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-validator</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7803,7 +7611,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonapi</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7818,7 +7626,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonata</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7833,7 +7641,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7848,7 +7656,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7863,7 +7671,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7878,7 +7686,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7897,7 +7705,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7912,12 +7720,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-reify</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7932,7 +7740,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kotlin-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7947,7 +7755,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.fabric8</groupId>
@@ -7966,7 +7774,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7981,7 +7789,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7996,7 +7804,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8011,7 +7819,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldif</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8026,7 +7834,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-leveldb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8041,7 +7849,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8056,7 +7864,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8075,7 +7883,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lucene</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8090,7 +7898,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lumberjack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8105,7 +7913,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lzf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8120,7 +7928,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8135,7 +7943,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8154,12 +7962,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8174,7 +7982,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8189,7 +7997,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8204,7 +8012,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8219,7 +8027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8238,7 +8046,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>javax.enterprise</groupId>
@@ -8257,7 +8065,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-metrics</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8280,7 +8088,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milo</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8295,7 +8103,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -8318,7 +8126,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8333,7 +8141,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8348,7 +8156,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb-gridfs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8367,7 +8175,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8386,7 +8194,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-msv</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8401,7 +8209,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mustache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8416,7 +8224,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mvel</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8431,7 +8239,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8446,7 +8254,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nagios</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8461,7 +8269,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8476,7 +8284,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8495,7 +8303,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8510,7 +8318,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nitrite</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8533,7 +8341,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nsq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -8564,7 +8372,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-oaipmh</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -8583,7 +8391,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ognl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8598,12 +8406,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -8622,7 +8430,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -8641,7 +8449,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openstack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.fge</groupId>
@@ -8664,7 +8472,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.grpc</groupId>
@@ -8683,7 +8491,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentracing</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8698,7 +8506,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-optaplanner</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8721,7 +8529,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8736,7 +8544,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8751,7 +8559,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pdf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -8770,7 +8578,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pg-replication-slot</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8785,7 +8593,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pgevent</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8804,7 +8612,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8819,12 +8627,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-printer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8839,7 +8647,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-protobuf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -8858,7 +8666,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pubnub</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8873,7 +8681,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pulsar</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -8916,7 +8724,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8939,7 +8747,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quickfix</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8958,7 +8766,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rabbitmq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8973,7 +8781,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-executor-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -8988,7 +8796,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-streams</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9003,7 +8811,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-redis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9018,7 +8826,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9033,7 +8841,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9048,7 +8856,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9063,7 +8871,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ribbon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -9086,7 +8894,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-robotframework</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9101,7 +8909,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rss</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9116,7 +8924,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9131,7 +8939,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9150,7 +8958,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sap-netweaver</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9165,7 +8973,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9180,7 +8988,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9195,7 +9003,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9210,7 +9018,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9225,7 +9033,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.messaging.saaj</groupId>
@@ -9256,7 +9064,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9271,7 +9079,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-shiro</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9286,7 +9094,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sip</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9301,7 +9109,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms2</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9316,7 +9124,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9331,7 +9139,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.googlecode.json-simple</groupId>
@@ -9350,7 +9158,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smpp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9365,7 +9173,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snakeyaml</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9380,7 +9188,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9395,7 +9203,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.xml.bind</groupId>
@@ -9406,7 +9214,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-solr</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -9429,7 +9237,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soroush</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9448,7 +9256,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -9467,7 +9275,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9482,7 +9290,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9513,7 +9321,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -9540,7 +9348,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9559,7 +9367,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stax</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9574,7 +9382,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stitch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9589,7 +9397,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stomp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9604,7 +9412,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stream</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9619,7 +9427,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stringtemplate</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9634,7 +9442,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9649,7 +9457,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9664,7 +9472,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-syslog</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9679,7 +9487,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tagsoup</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9694,7 +9502,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tarfile</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9709,7 +9517,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9724,7 +9532,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-threadpoolfactory-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9739,7 +9547,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-thrift</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -9762,7 +9570,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tika</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9781,7 +9589,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9796,17 +9604,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twilio</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9837,7 +9645,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twitter</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9852,7 +9660,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-univocity-parsers</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9867,17 +9675,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9892,7 +9700,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9907,12 +9715,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9927,7 +9735,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9942,7 +9750,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9957,7 +9765,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vm</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -9972,7 +9780,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weather</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -9991,7 +9799,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-web3j</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10006,7 +9814,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10021,7 +9829,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weka</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10036,7 +9844,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wordpress</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10059,7 +9867,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-workday</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -10078,7 +9886,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xchange</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -10105,7 +9913,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10120,7 +9928,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10135,12 +9943,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10155,7 +9963,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10170,7 +9978,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10185,7 +9993,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmlsecurity</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10200,7 +10008,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmpp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10215,7 +10023,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10230,7 +10038,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10245,7 +10053,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10260,7 +10068,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xstream</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10275,17 +10083,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10300,7 +10108,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yammer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10315,7 +10123,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zendesk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10330,7 +10138,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10345,7 +10153,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10360,7 +10168,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper-master</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10375,7 +10183,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -10420,11 +10228,6 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>connect-api</artifactId>
-        <version>3.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>connect-file</artifactId>
         <version>3.1.0</version>
       </dependency>
       <dependency>
@@ -10562,97 +10365,97 @@
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-common</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-hpack</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-http-client-transport</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
@@ -10662,12 +10465,17 @@
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>
-        <version>21.3.2</version>
+        <version>21.3.1</version>
       </dependency>
       <dependency>
         <groupId>org.hdrhistogram</groupId>
         <artifactId>HdrHistogram</artifactId>
         <version>2.1.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-jboss-marshalling</artifactId>
+        <version>13.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId>
@@ -10742,22 +10550,22 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -10768,27 +10576,17 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>5.3.20</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-jdbc</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>5.3.20</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-orm</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.threeten</groupId>
@@ -10824,12 +10622,6 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>apache-client</artifactId>
         <version>2.17.121</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -10491,7 +10491,7 @@
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-jboss-marshalling</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-sftp</artifactId>
-      <version>2.8.0</version>
+      <version>2.7.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-scp</artifactId>
-      <version>2.8.0</version>
+      <version>2.7.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
@@ -38,39 +38,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.icegreen</groupId>
-      <artifactId>greenmail</artifactId>
-      <version>1.6.7</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit4-mock</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
@@ -54,12 +54,6 @@
       <artifactId>quarkus-junit4-mock</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.camel.quarkus</groupId>
-      <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>${camel-quarkus.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/generated-platform-project/quarkus-debezium/bom/pom.xml
+++ b/generated-platform-project/quarkus-debezium/bom/pom.xml
@@ -117,36 +117,6 @@
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
         <version>1.8.1.Final</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-log4j-appender</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-runtime</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-file</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>

--- a/generated-platform-project/quarkus-debezium/bom/pom.xml
+++ b/generated-platform-project/quarkus-debezium/bom/pom.xml
@@ -117,6 +117,36 @@
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
         <version>1.8.1.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-log4j-appender</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-file</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>

--- a/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
@@ -2108,16 +2108,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>30.1.1-jre</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>listenablefuture</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
@@ -2168,12 +2158,6 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
         <version>3.19.3</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>

--- a/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
@@ -2157,12 +2157,12 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
       </dependency>
       <dependency>
         <groupId>io.grafeas</groupId>

--- a/generated-platform-project/quarkus-maven-plugin/pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/pom.xml
@@ -197,6 +197,33 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <pomElements>
+                <repositories>remove</repositories>
+                <build>remove</build>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -423,177 +423,177 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4.2</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-avro</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-cbor</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-csv</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-ion</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-properties</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-protobuf</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-smile</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-toml</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-xml</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-eclipse-collections</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate4</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate5-jakarta</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate5</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hppc</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jaxrs</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jdk8</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda-money</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-json-org</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr353</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-pcollections</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-base</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-cbor-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-smile-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-xml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-base</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -604,12 +604,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-cbor-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -620,67 +620,67 @@
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-smile-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-xml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-yaml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-all</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-annotation-support</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-objects</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-retrofit2</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-stree</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-afterburner</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-blackbird</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-guice</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -701,57 +701,57 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jsonSchema</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-kotlin</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-mrbean</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-no-ctor-deser</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-osgi</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-parameter-names</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-paranamer</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.11</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.12</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.13</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_3</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
@@ -3010,7 +3010,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -3021,54 +3021,54 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>linux-x86_32</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>windows-x86_32</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>windows-x86_64</classifier>
       </dependency>
@@ -4464,6 +4464,14 @@
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-annotations-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -5723,12 +5731,12 @@
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.gizmo</groupId>
@@ -5793,57 +5801,57 @@
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-generator</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-vertx</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.security</groupId>
@@ -5863,622 +5871,622 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-alexa-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-alexa</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-dynamodb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-dynamodb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-iam-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-iam</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-kms-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-kms</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-event-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-event-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-event-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-s3-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-s3</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-secretsmanager-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-secretsmanager</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ses-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ses</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sns-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sns</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sqs-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sqs</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ssm-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ssm</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arquillian</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-core-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-jms-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-jms</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-app-model</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-gradle-resolver</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-runner</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-builder</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-class-change-agent</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-consul-config-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-consul-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-util</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-development-mode-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-db2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-derby</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-h2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mariadb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mssql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mysql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-oracle</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-postgresql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-registry-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-testing</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-utilities</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -6488,103 +6496,103 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-amazon-lambda</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-codegen</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-protoc-plugin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-stubs</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6595,142 +6603,142 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-aws-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-aws</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-ide-launcher</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>*</groupId>
@@ -6741,1334 +6749,1334 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-spi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-db2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-derby</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jgit-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jgit</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsch-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsch</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit4-mock</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-internal</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-properties</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-sentry-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-sentry</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-neo4j-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-neo4j</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-mock</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panacheql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-project-core-extension-codestarts</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-messaging-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-messaging-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-server-spi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-spi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-runtime-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -8079,12 +8087,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -8095,82 +8103,97 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-reactive-messaging-amqp-deployment</artifactId>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-reactive-messaging-mqtt-deployment</artifactId>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq-deployment</artifactId>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -8190,32 +8213,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -8240,12 +8263,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -8255,32 +8278,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -8290,12 +8313,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -8305,37 +8328,37 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -8345,222 +8368,222 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-amazon-lambda</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-artemis</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-derby</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-h2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-infinispan-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-keycloak-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-kubernetes-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-ldap</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-mongodb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-oidc-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-openshift-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-jwt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-oidc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-vault</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-vertx</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-tika-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-tika</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-websockets</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-web-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-web</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.reactivex.rxjava2</groupId>
@@ -8698,27 +8721,27 @@
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-common</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-source-file-system</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-source-yaml</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-validator</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.osgi</groupId>
@@ -19969,6 +19992,11 @@
         <version>3.6.1</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.10.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-client</artifactId>
         <version>4.3.0</version>
@@ -20355,6 +20383,16 @@
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
         <version>1.5.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-common</artifactId>
+        <version>2.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-core</artifactId>
+        <version>2.9.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tinkerpop</groupId>
@@ -21436,94 +21474,94 @@
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-processor</artifactId>
-        <version>4.4.1.Final</version>
+        <version>4.4.3.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-types</artifactId>
-        <version>4.4.1.Final</version>
+        <version>4.4.3.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream</artifactId>
-        <version>4.4.1.Final</version>
+        <version>4.4.3.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-client-hotrod</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons-test</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-component-annotations</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-jboss-marshalling</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-objectfilter</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query-dsl</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-client</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-server</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-testdriver-core</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId>
@@ -24840,7 +24878,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.3</version>
+        <version>42.5.1</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -25286,7 +25324,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.30</version>
+        <version>1.33</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -65,50 +65,12 @@
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-base</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-client</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir-server</artifactId>
         <version>4.1.0</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -126,37 +88,6 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-structures-dstu3</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
           </exclusion>
@@ -170,174 +101,6 @@
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-structures-r4</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>hapi-fhir-structures-r5</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.dstu2</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.dstu3</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.r4</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.r5</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>ca.uhn.hapi.fhir</groupId>
-        <artifactId>org.hl7.fhir.utilities</artifactId>
-        <version>4.1.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -1082,11 +845,6 @@
             <artifactId>asm-util</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.github.mwiede</groupId>
-        <artifactId>jsch</artifactId>
-        <version>0.2.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
@@ -3355,6 +3113,16 @@
         <version>2.4.0</version>
       </dependency>
       <dependency>
+        <groupId>com.jcraft</groupId>
+        <artifactId>jzlib</artifactId>
+        <version>1.1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.mchange</groupId>
+        <artifactId>c3p0</artifactId>
+        <version>0.9.5.5</version>
+      </dependency>
+      <dependency>
         <groupId>com.microsoft.azure.functions</groupId>
         <artifactId>azure-functions-java-library</artifactId>
         <version>1.4.2</version>
@@ -3646,7 +3414,7 @@
       <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>jakarta.mail</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -3667,7 +3435,7 @@
       <dependency>
         <groupId>com.zendesk</groupId>
         <artifactId>mysql-binlog-connector-java</artifactId>
-        <version>0.25.4</version>
+        <version>0.25.1</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -3821,6 +3589,36 @@
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
         <version>1.8.1.Final</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-log4j-appender</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-file</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
@@ -3828,6 +3626,30 @@
         <version>1.8.1.Final</version>
         <classifier>tests</classifier>
         <exclusions>
+          <exclusion>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-log4j-appender</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-file</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
@@ -10699,3387 +10521,3387 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc-ws-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc-ws</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ahc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atlasmap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atlasmap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atmos-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atmos</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atomix-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atomix</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-rpc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-rpc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanstalk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanstalk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-lrucache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-lrucache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-catalog</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cmis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cmis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-corda-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-corda</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dozer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dozer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elsql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elsql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-facebook-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-facebook</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ganglia-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ganglia</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hbase-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hbase</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hdfs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hdfs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hystrix-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hystrix</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iota-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iota</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ipfs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ipfs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jbpm-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jbpm</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jclouds-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jclouds</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jing-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jing</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-johnzon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-johnzon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-reify-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-reify</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-client</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-metrics-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-metrics</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milo-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milo</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-msv-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-msv</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nagios-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nagios</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nsq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nsq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentracing-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentracing</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-component</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rabbitmq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rabbitmq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ribbon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ribbon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sip-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sip</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soroush-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soroush</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-beans</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-context</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-core</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-stax-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-stax</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xstream-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xstream</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tagsoup-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tagsoup</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vm-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vm</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weka-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weka</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xstream-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xstream</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yammer-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yammer</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master-deployment</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-activemq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14110,7 +13932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ahc-ws</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14125,7 +13947,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ahc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14148,7 +13970,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -14179,7 +14001,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14194,7 +14016,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-arangodb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14209,12 +14031,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14241,7 +14063,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asn1</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14256,7 +14078,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asterisk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -14275,7 +14097,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atlasmap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14294,7 +14116,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atmos</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14317,7 +14139,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atom</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14340,7 +14162,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atomix</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14355,7 +14177,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -14374,7 +14196,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro-rpc-spi</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>javax.annotation</groupId>
@@ -14389,7 +14211,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro-rpc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14412,7 +14234,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14435,7 +14257,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14454,7 +14276,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-xray</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14473,7 +14295,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-athena</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14496,7 +14318,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14519,7 +14341,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14542,7 +14364,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ec2</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14565,7 +14387,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ecs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14588,7 +14410,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eks</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14611,7 +14433,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eventbridge</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14634,7 +14456,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-iam</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14657,7 +14479,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14680,7 +14502,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14703,7 +14525,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14726,7 +14548,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-mq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14749,7 +14571,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-msk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14772,7 +14594,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14795,7 +14617,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ses</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14818,7 +14640,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14841,7 +14663,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14864,7 +14686,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sts</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14887,7 +14709,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-translate</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -14910,7 +14732,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-cosmosdb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14925,7 +14747,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -14944,7 +14766,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -14963,7 +14785,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -14978,7 +14800,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -14997,7 +14819,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-barcode</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15012,12 +14834,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base64</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15032,7 +14854,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15047,7 +14869,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15066,7 +14888,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15081,7 +14903,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15096,7 +14918,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanstalk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15111,7 +14933,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15126,7 +14948,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bonita</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15149,12 +14971,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -15173,7 +14995,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-braintree</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15188,7 +15010,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15203,7 +15025,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine-lrucache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15218,7 +15040,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15233,7 +15055,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -15252,7 +15074,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15267,7 +15089,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cbor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15282,7 +15104,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chatscript</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15297,7 +15119,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chunk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15312,7 +15134,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15327,12 +15149,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cm-sms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -15355,7 +15177,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cmis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>asm</groupId>
@@ -15382,7 +15204,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-coap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15397,7 +15219,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cometd</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15416,7 +15238,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15431,7 +15253,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-consul</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -15454,7 +15276,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15469,7 +15291,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-corda</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -15508,7 +15330,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15523,7 +15345,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15538,7 +15360,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15553,12 +15375,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15573,12 +15395,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchbase</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15593,7 +15415,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchdb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -15612,7 +15434,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15627,7 +15449,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15642,7 +15464,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-csv</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15657,7 +15479,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15672,7 +15494,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15695,7 +15517,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mongodb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15722,7 +15544,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mysql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15749,7 +15571,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-postgres</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15776,7 +15598,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-sqlserver</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15803,7 +15625,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-digitalocean</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -15822,7 +15644,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15837,7 +15659,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-disruptor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15852,7 +15674,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15867,7 +15689,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dns</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15882,7 +15704,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dozer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15905,7 +15727,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-drill</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -15928,7 +15750,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dropbox</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15943,12 +15765,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ehcache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15963,7 +15785,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15982,7 +15804,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elsql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -15997,7 +15819,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16012,7 +15834,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd3</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16027,7 +15849,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16042,7 +15864,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-exec</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16057,7 +15879,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-facebook</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16072,7 +15894,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fastjson</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16087,12 +15909,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16119,7 +15941,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file-watch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16134,7 +15956,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16149,7 +15971,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flatpack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16164,7 +15986,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16183,7 +16005,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fop</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -16202,7 +16024,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-freemarker</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16217,7 +16039,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16232,7 +16054,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ganglia</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16247,7 +16069,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-geocoder</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16270,7 +16092,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-git</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16285,7 +16107,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-github</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16300,7 +16122,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16335,7 +16157,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-calendar</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16358,7 +16180,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-drive</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16381,7 +16203,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-functions</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16408,7 +16230,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-mail</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16431,7 +16253,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16474,7 +16296,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-sheets</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16497,7 +16319,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-storage</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16532,7 +16354,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -16551,7 +16373,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grok</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16566,12 +16388,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16586,7 +16408,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16601,7 +16423,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16624,7 +16446,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16639,7 +16461,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-guava-eventbus</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16654,7 +16476,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hazelcast</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16669,7 +16491,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hbase</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16700,7 +16522,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hdfs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16743,7 +16565,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-headersmap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -16766,12 +16588,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16786,12 +16608,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16806,7 +16628,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16829,12 +16651,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-smn</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16849,7 +16671,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hystrix</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -16868,7 +16690,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ical</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -16887,7 +16709,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iec60870</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -16906,7 +16728,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ignite</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16921,18 +16743,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>3.14.4</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16948,22 +16764,14 @@
           </exclusion>
           <exclusion>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-jboss-marshalling</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-marshaller-protostuff</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jgroups</groupId>
-            <artifactId>jgroups</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-influxdb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -16978,7 +16786,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iota</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -16997,12 +16805,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ipfs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-irc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17017,7 +16825,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17032,7 +16840,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17047,7 +16855,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17062,7 +16870,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17077,7 +16885,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17092,7 +16900,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17107,7 +16915,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17122,7 +16930,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbpm</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17149,7 +16957,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17164,7 +16972,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jclouds</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -17191,7 +16999,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcr</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17210,7 +17018,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17233,7 +17041,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17248,7 +17056,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups-raft</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17263,7 +17071,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17278,7 +17086,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jing</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17293,7 +17101,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17344,7 +17152,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17379,7 +17187,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-johnzon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17394,7 +17202,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jolt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17413,7 +17221,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jooq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>javax.activation</groupId>
@@ -17440,7 +17248,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17455,7 +17263,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17486,7 +17294,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-js-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17501,7 +17309,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17516,7 +17324,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17531,7 +17339,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-patch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17546,7 +17354,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-validator</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17561,7 +17369,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonapi</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17576,7 +17384,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonata</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17591,7 +17399,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17606,7 +17414,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17621,7 +17429,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17636,7 +17444,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17655,7 +17463,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17670,12 +17478,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-reify</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17690,7 +17498,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kotlin-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17705,7 +17513,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.fabric8</groupId>
@@ -17724,7 +17532,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17739,7 +17547,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17754,7 +17562,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17769,7 +17577,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldif</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17784,7 +17592,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-leveldb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17799,7 +17607,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17814,7 +17622,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17833,7 +17641,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lucene</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17848,7 +17656,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lumberjack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17863,7 +17671,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lzf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17878,7 +17686,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17893,7 +17701,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17912,12 +17720,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17932,7 +17740,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17947,7 +17755,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17962,7 +17770,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17977,7 +17785,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -17996,7 +17804,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>javax.enterprise</groupId>
@@ -18015,7 +17823,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-metrics</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18038,7 +17846,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milo</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18053,7 +17861,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -18076,7 +17884,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18091,7 +17899,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18106,7 +17914,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb-gridfs</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18125,7 +17933,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18144,7 +17952,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-msv</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18159,7 +17967,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mustache</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18174,7 +17982,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mvel</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18189,7 +17997,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18204,7 +18012,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nagios</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18219,7 +18027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18234,7 +18042,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18253,7 +18061,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18268,7 +18076,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nitrite</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18291,7 +18099,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nsq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -18322,7 +18130,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-oaipmh</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18341,7 +18149,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ognl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18356,12 +18164,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18380,7 +18188,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -18399,7 +18207,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openstack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.fge</groupId>
@@ -18422,7 +18230,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>io.grpc</groupId>
@@ -18441,7 +18249,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentracing</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18456,7 +18264,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-optaplanner</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18479,7 +18287,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18494,7 +18302,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18509,7 +18317,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pdf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18528,7 +18336,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pg-replication-slot</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18543,7 +18351,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pgevent</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18562,7 +18370,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18577,12 +18385,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-printer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18597,7 +18405,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-protobuf</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -18616,7 +18424,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pubnub</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18631,7 +18439,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pulsar</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -18674,7 +18482,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18697,7 +18505,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quickfix</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18716,7 +18524,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rabbitmq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18731,7 +18539,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-executor-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18746,7 +18554,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-streams</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18761,7 +18569,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-redis</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18776,7 +18584,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18791,7 +18599,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18806,7 +18614,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18821,7 +18629,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ribbon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -18844,7 +18652,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-robotframework</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18859,7 +18667,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rss</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18874,7 +18682,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18889,7 +18697,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18908,7 +18716,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sap-netweaver</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18923,7 +18731,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18938,7 +18746,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18953,7 +18761,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18968,7 +18776,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18983,7 +18791,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.messaging.saaj</groupId>
@@ -19014,7 +18822,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19029,7 +18837,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-shiro</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19044,7 +18852,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sip</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19059,7 +18867,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms2</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19074,7 +18882,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19089,7 +18897,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.googlecode.json-simple</groupId>
@@ -19108,7 +18916,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smpp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19123,7 +18931,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snakeyaml</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19138,7 +18946,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19153,7 +18961,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.xml.bind</groupId>
@@ -19164,7 +18972,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-solr</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19187,7 +18995,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soroush</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19206,7 +19014,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19225,7 +19033,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19240,7 +19048,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19271,7 +19079,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19298,7 +19106,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19317,7 +19125,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stax</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19332,7 +19140,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stitch</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19347,7 +19155,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stomp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19362,7 +19170,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stream</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19377,7 +19185,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stringtemplate</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19392,7 +19200,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19407,7 +19215,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19422,7 +19230,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-syslog</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19437,7 +19245,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tagsoup</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19452,7 +19260,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tarfile</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19467,7 +19275,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19482,7 +19290,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-threadpoolfactory-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19497,7 +19305,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-thrift</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19520,7 +19328,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tika</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19539,7 +19347,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19554,17 +19362,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twilio</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19595,7 +19403,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twitter</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19610,7 +19418,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-univocity-parsers</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19625,17 +19433,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19650,7 +19458,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19665,12 +19473,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19685,7 +19493,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19700,7 +19508,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19715,7 +19523,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vm</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19730,7 +19538,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weather</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19749,7 +19557,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-web3j</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19764,7 +19572,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19779,7 +19587,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weka</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19794,7 +19602,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wordpress</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19817,7 +19625,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-workday</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19836,7 +19644,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xchange</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -19863,7 +19671,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19878,7 +19686,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19893,12 +19701,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19913,7 +19721,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19928,7 +19736,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19943,7 +19751,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmlsecurity</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19958,7 +19766,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmpp</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19973,7 +19781,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19988,7 +19796,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20003,7 +19811,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20018,7 +19826,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xstream</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20033,17 +19841,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20058,7 +19866,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yammer</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20073,7 +19881,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zendesk</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20088,7 +19896,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20103,7 +19911,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20118,7 +19926,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper-master</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20133,7 +19941,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper</artifactId>
-        <version>3.14.4</version>
+        <version>3.14.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20233,11 +20041,6 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>connect-api</artifactId>
-        <version>3.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>connect-file</artifactId>
         <version>3.1.0</version>
       </dependency>
       <dependency>
@@ -21292,97 +21095,97 @@
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-common</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-hpack</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-http-client-transport</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
@@ -21545,7 +21348,7 @@
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>
-        <version>21.3.2</version>
+        <version>21.3.1</version>
       </dependency>
       <dependency>
         <groupId>org.graalvm.nativeimage</groupId>
@@ -21675,6 +21478,11 @@
         <artifactId>infinispan-core</artifactId>
         <version>13.0.8.Final</version>
         <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-jboss-marshalling</artifactId>
+        <version>13.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
@@ -25084,22 +24892,22 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -25110,27 +24918,17 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>5.3.20</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-jdbc</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>5.3.20</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-orm</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>5.3.20</version>
+        <version>5.3.16</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
@@ -25544,12 +25342,6 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>apache-client</artifactId>
         <version>2.17.121</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/generated-platform-project/quarkus-universe/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus-universe/descriptor/src/main/resources/overrides.json
@@ -9,19 +9,21 @@
         "kotlin-version" : "1.6.10",
         "scala-version" : "2.12.13",
         "scala-plugin-version" : "4.5.6",
-        "quarkus-core-version" : "2.7.6.Final",
+        "quarkus-core-version" : "2.7.7.Final",
         "maven-plugin-groupId" : "io.quarkus",
         "maven-plugin-artifactId" : "quarkus-maven-plugin",
-        "maven-plugin-version" : "2.7.6.Final",
+        "maven-plugin-version" : "2.7.7.Final",
         "gradle-plugin-id" : "io.quarkus",
-        "gradle-plugin-version" : "2.7.6.Final",
+        "gradle-plugin-version" : "2.7.7.Final",
         "supported-maven-versions" : "[3.6.2,)",
         "proposed-maven-version" : "3.8.4",
         "maven-wrapper-version" : "3.1.0",
-        "gradle-wrapper-version" : "7.3.3"
+        "gradle-wrapper-version" : "7.3.3",
+        "minimum-java-version" : "11",
+        "recommended-java-version" : "17"
       }
     },
-    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:2.7.6.Final" ]
+    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:2.7.7.Final" ]
   },
   "categories" : [ {
     "id" : "web",

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -115,307 +115,307 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4.2</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-avro</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-cbor</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-csv</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-ion</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-properties</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-protobuf</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-smile</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-toml</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-xml</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-eclipse-collections</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate4</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate5-jakarta</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate5</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hppc</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jakarta-jsonp</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jaxrs</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jdk8</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda-money</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-json-org</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr353</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-pcollections</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-base</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-cbor-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-smile-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-xml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-base</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-cbor-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-smile-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-xml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-yaml-provider</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-all</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-annotation-support</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-objects</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-retrofit2</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jr</groupId>
         <artifactId>jackson-jr-stree</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-afterburner</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-blackbird</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-guice</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jsonSchema</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-kotlin</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-mrbean</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-no-ctor-deser</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-osgi</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-parameter-names</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-paranamer</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.11</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.12</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.13</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_3</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml</groupId>
@@ -596,7 +596,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -607,54 +607,54 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>linux-x86_32</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>windows-x86_32</classifier>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protoc</artifactId>
-        <version>3.19.3</version>
+        <version>3.19.6</version>
         <type>exe</type>
         <classifier>windows-x86_64</classifier>
       </dependency>
@@ -1737,6 +1737,14 @@
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-annotations-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -2771,12 +2779,12 @@
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.gizmo</groupId>
@@ -2841,57 +2849,57 @@
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-generator</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-processor</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-vertx</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.security</groupId>
@@ -2911,622 +2919,622 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-alexa-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-alexa</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-dynamodb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-dynamodb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-iam-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-iam</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-kms-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-kms</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-event-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-event-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-event-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-s3-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-s3</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-secretsmanager-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-secretsmanager</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ses-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ses</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sns-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sns</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sqs-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-sqs</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ssm-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-ssm</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arquillian</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-core-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-jms-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-artemis-jms</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-app-model</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-gradle-resolver</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-runner</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-builder</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-class-change-agent</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-consul-config-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-consul-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-util</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-development-mode-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-db2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-derby</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-h2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mariadb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mssql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mysql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-oracle</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-postgresql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-registry-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-testing</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-utilities</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -3536,103 +3544,103 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-amazon-lambda</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-codegen</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-protoc-plugin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-stubs</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -3643,142 +3651,142 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-aws-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-aws</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-ide-launcher</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>*</groupId>
@@ -3789,1334 +3797,1334 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-spi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-db2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-derby</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jgit-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jgit</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsch-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsch</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit4-mock</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-internal</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-properties</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-sentry-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-sentry</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-neo4j-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-neo4j</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-mock</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panacheql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-project-core-extension-codestarts</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-messaging-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-messaging-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-server-spi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-spi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-runtime-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-common-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -5127,12 +5135,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -5143,82 +5151,97 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-reactive-messaging-amqp-deployment</artifactId>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kotlin</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-reactive-messaging-mqtt-deployment</artifactId>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq-deployment</artifactId>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5238,32 +5261,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5288,12 +5311,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5303,32 +5326,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5338,12 +5361,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5353,37 +5376,37 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5393,222 +5416,222 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-amazon-lambda</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-artemis</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-common</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-derby</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-h2</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-infinispan-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-keycloak-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-kubernetes-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-ldap</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-mongodb</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-oidc-server</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-openshift-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-jwt</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-oidc</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-vault</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-vertx</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-tika-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-tika</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-websockets</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-web-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-web</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-deployment</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets</artifactId>
-        <version>2.7.6.Final</version>
+        <version>2.7.7.Final</version>
       </dependency>
       <dependency>
         <groupId>io.reactivex.rxjava2</groupId>
@@ -5746,27 +5769,27 @@
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-common</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-source-file-system</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-source-yaml</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config-validator</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config</artifactId>
-        <version>2.9.2</version>
+        <version>2.9.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.osgi</groupId>
@@ -7476,6 +7499,11 @@
         <version>3.12.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.10.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derbyclient</artifactId>
         <version>10.14.2.0</version>
@@ -7765,6 +7793,16 @@
         <groupId>org.apache.qpid</groupId>
         <artifactId>proton-j</artifactId>
         <version>0.33.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-common</artifactId>
+        <version>2.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-core</artifactId>
+        <version>2.9.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
@@ -8061,89 +8099,89 @@
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-processor</artifactId>
-        <version>4.4.1.Final</version>
+        <version>4.4.3.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-types</artifactId>
-        <version>4.4.1.Final</version>
+        <version>4.4.3.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream</artifactId>
-        <version>4.4.1.Final</version>
+        <version>4.4.3.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-client-hotrod</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons-test</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-component-annotations</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-objectfilter</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query-dsl</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-client</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-server</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-testdriver-core</artifactId>
-        <version>13.0.8.Final</version>
+        <version>13.0.10.Final</version>
       </dependency>
       <dependency>
         <groupId>org.jacoco</groupId>
@@ -8974,7 +9012,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.3</version>
+        <version>42.5.1</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -9349,7 +9387,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.30</version>
+        <version>1.33</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus/descriptor/src/main/resources/overrides.json
@@ -9,19 +9,21 @@
         "kotlin-version" : "1.6.10",
         "scala-version" : "2.12.13",
         "scala-plugin-version" : "4.5.6",
-        "quarkus-core-version" : "2.7.6.Final",
+        "quarkus-core-version" : "2.7.7.Final",
         "maven-plugin-groupId" : "${project.groupId}",
         "maven-plugin-artifactId" : "quarkus-maven-plugin",
         "maven-plugin-version" : "${project.version}",
         "gradle-plugin-id" : "io.quarkus",
-        "gradle-plugin-version" : "2.7.6.Final",
+        "gradle-plugin-version" : "2.7.7.Final",
         "supported-maven-versions" : "[3.6.2,)",
         "proposed-maven-version" : "3.8.4",
         "maven-wrapper-version" : "3.1.0",
-        "gradle-wrapper-version" : "7.3.3"
+        "gradle-wrapper-version" : "7.3.3",
+        "minimum-java-version" : "11",
+        "recommended-java-version" : "17"
       }
     },
-    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:2.7.6.Final" ],
+    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:2.7.7.Final" ],
     "last-bom-update" : "${member.last-bom-update}"
   },
   "categories" : [ {

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <quarkus-google-cloud-services.version>1.0.0</quarkus-google-cloud-services.version>
         <quarkus-vault.version>1.0.2</quarkus-vault.version>
 
-        <quarkus-platform-bom-generator.version>0.0.48</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.60</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkus.version>2.7.6.Final</quarkus.version>
         <quarkus-bom.version>${quarkus.version}</quarkus-bom.version>
 
-        <camel-quarkus.version>2.7.2</camel-quarkus.version>
+        <camel-quarkus.version>2.7.1</camel-quarkus.version>
 
         <!-- If you made changes to the integration tests pom of Amazon Services,
              make sure you have a look at the AmazonServices member section below

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
-        <quarkus.version>2.7.6.Final</quarkus.version>
+        <quarkus.version>2.7.7.Final</quarkus.version>
         <quarkus-bom.version>${quarkus.version}</quarkus-bom.version>
 
         <camel-quarkus.version>2.7.1</camel-quarkus.version>


### PR DESCRIPTION
Reverting upgrade to Camel Quarkus 2.7.2 from the 2.7 platform branch following our discussion with @ppalaga, @tqvarnst and @maxandersen.