### PR TITLE
Drop quarkus-opentelemetry-exporter-jaeger from 2.13 branch

### DIFF
--- a/src/main/resources/core/extensions-support-overrides.json
+++ b/src/main/resources/core/extensions-support-overrides.json
@@ -426,15 +426,6 @@
     },
     {
       "group-id": "io.quarkus",
-      "artifact-id": "quarkus-opentelemetry-exporter-jaeger",
-      "metadata": {
-        "redhat-support": [
-          "tech-preview"
-        ]
-      }
-    },
-    {
-      "group-id": "io.quarkus",
       "artifact-id": "quarkus-quartz",
       "metadata": {
         "redhat-support": [


### PR DESCRIPTION
Issue coming from https://issues.redhat.com/browse/QUARKUS-2394
Drop the Jaeger exporter from the platform. The Jaeger extension will move to quarkiverse and the platform will rely on quarkus-opentelemetry, which will include a default otlp exporter.