### PR TITLE
Update resteasy-mutiny and reactive routes support scope

### DIFF
--- a/src/main/resources/core/extensions-support-overrides.json
+++ b/src/main/resources/core/extensions-support-overrides.json
@@ -501,7 +501,7 @@
       "artifact-id": "quarkus-reactive-routes",
       "metadata": {
         "redhat-support": [
-          "supported"
+          "deprecated"
         ]
       }
     },
@@ -546,7 +546,7 @@
       "artifact-id": "quarkus-rest-client-mutiny",
       "metadata": {
         "redhat-support": [
-          "tech-preview"
+          "deprecated"
         ]
       }
     },
@@ -618,7 +618,7 @@
       "artifact-id": "quarkus-resteasy-mutiny",
       "metadata": {
         "redhat-support": [
-          "tech-preview"
+          "deprecated"
         ]
       }
     },


### PR DESCRIPTION
- RESTEasy Mutiny (server and client) are deprecated -> move to RESTEasy reactive
- Reactive Routes are deprecated -> move to RESTEasy reactive


