### PR TITLE
Upgrade to the platform generator 0.0.63

### DIFF
--- a/generated-platform-project/quarkus-maven-plugin/pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/pom.xml
@@ -214,6 +214,7 @@
             <configuration>
               <flattenMode>oss</flattenMode>
               <pomElements>
+                <dependencyManagement>keep</dependencyManagement>
                 <repositories>remove</repositories>
                 <build>remove</build>
               </pomElements>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -10416,11 +10416,13 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config-common</artifactId>
         <version>1.5.0</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>1.5.0</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
@@ -10947,6 +10949,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-aggregator</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -10962,6 +10965,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11002,6 +11006,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-infinispan-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11083,6 +11088,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11278,6 +11284,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11314,6 +11321,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tracing-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -6644,11 +6644,13 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config-common</artifactId>
         <version>1.5.0</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>1.5.0</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
@@ -7170,6 +7172,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-aggregator</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7185,6 +7188,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7225,6 +7229,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-infinispan-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7306,6 +7311,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7501,6 +7507,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7537,6 +7544,7 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tracing-parent</artifactId>
         <version>4.3.3</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <quarkus-vault.version>2.0.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>4.0.3</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.61</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.63</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>


### PR DESCRIPTION
* keep the platform BOM import in the flattened POM of the generated Maven plugin to make sure the transitive dependencies of the plugin are aligned
* Detect some POM constraints in BOMs configured as JARs and add `<type>pom</type>` to them
* fixes in release detectors.
* fixes in dependencies to build report generator