### PR TITLE
Drop TP metadata for resteasy-mutiny extensions, security-jpa and vertx-graphql

### DIFF
--- a/src/main/resources/core/extensions-support-overrides.json
+++ b/src/main/resources/core/extensions-support-overrides.json
@@ -534,15 +534,6 @@
     },
     {
       "group-id": "io.quarkus",
-      "artifact-id": "quarkus-rest-client-mutiny",
-      "metadata": {
-        "redhat-support": [
-          "tech-preview"
-        ]
-      }
-    },
-    {
-      "group-id": "io.quarkus",
       "artifact-id": "quarkus-rest-client-reactive",
       "metadata": {
         "redhat-support": [
@@ -606,15 +597,6 @@
     },
     {
       "group-id": "io.quarkus",
-      "artifact-id": "quarkus-resteasy-mutiny",
-      "metadata": {
-        "redhat-support": [
-          "tech-preview"
-        ]
-      }
-    },
-    {
-      "group-id": "io.quarkus",
       "artifact-id": "quarkus-resteasy-qute",
       "metadata": {
         "redhat-support": [
@@ -673,15 +655,6 @@
       "metadata": {
         "redhat-support": [
           "supported"
-        ]
-      }
-    },
-    {
-      "group-id": "io.quarkus",
-      "artifact-id": "quarkus-security-jpa",
-      "metadata": {
-        "redhat-support": [
-          "tech-preview"
         ]
       }
     },
@@ -888,15 +861,6 @@
       "metadata": {
         "redhat-support": [
           "supported"
-        ]
-      }
-    },
-    {
-      "group-id": "io.quarkus",
-      "artifact-id": "quarkus-vertx-graphql",
-      "metadata": {
-        "redhat-support": [
-          "tech-preview"
         ]
       }
     },


### PR DESCRIPTION
Drop TP metadata for resteasy-mutiny extensions, security-jpa and vertx-graphql

https://issues.redhat.com/browse/QUARKUS-2392
https://issues.redhat.com/browse/QUARKUS-2393
https://issues.redhat.com/browse/QUARKUS-2395
https://issues.redhat.com/browse/QUARKUS-2396
