### PR TITLE
[2.13] Reminder: Upgrade to Camel Quarkus 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkus.version>2.13.3.Final</quarkus.version>
         <quarkus-bom.version>${quarkus.version}</quarkus-bom.version>
 
-        <camel-quarkus.version>2.13.0</camel-quarkus.version>
+        <camel-quarkus.version>2.13.1</camel-quarkus.version>
         <camel-quarkus-test-list.version>${camel-quarkus.version}</camel-quarkus-test-list.version>
 
         <!-- If you made changes to the integration tests pom of Amazon Services,
@@ -447,10 +447,6 @@
                                         <test><!-- Workaround incompatible PostgreSQL JDBC driver -->
                                             <skip>true</skip>
                                             <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-debezium:${camel-quarkus-test-list.version}</artifact>
-                                        </test>
-                                        <test><!-- https://github.com/apache/camel-quarkus/issues/4058 -->
-                                            <skip>true</skip>
-                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cxf-soap:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                     </tests>
                                 </member>

--- a/src/main/resources/xslt/camel/test-pom.xsl
+++ b/src/main/resources/xslt/camel/test-pom.xsl
@@ -122,4 +122,22 @@
         </xsl:copy>
     </xsl:template>
 
+    <!-- Disabled because of https://github.com/apache/camel-quarkus/issues/4254 -->
+    <xsl:template match="//pom:configuration[../pom:artifactId/text() = 'maven-surefire-plugin' and /pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-cxf-soap-grouped']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" />
+            <xsl:comment>Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4254</xsl:comment>
+            <test>!*IT,!CxfSoapClientTest#wsdlUpToDate,!CxfSoapWssClientTest#wsdlUpToDate</test>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Disabled because of https://github.com/apache/camel-quarkus/issues/4255 -->
+    <xsl:template match="//pom:configuration[../pom:artifactId/text() = 'maven-surefire-plugin' and /pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-xml']">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" />
+            <xsl:comment>Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4255</xsl:comment>
+            <test>!*IT,!XmlTest#aggregate,!XmlTest#xsltSchemas</test>
+        </xsl:copy>
+    </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
A more complete replacement for https://github.com/quarkusio/quarkus-platform/pull/685

This needs to be applied after upgrading to Quarkus core 2.13.4. `mvn -Dsync` is TBD.