### PR TITLE
Upgrade to platform generator 0.0.66

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -10523,13 +10523,11 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config-common</artifactId>
         <version>1.5.0</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>1.5.0</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
@@ -11054,12 +11052,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-aggregator</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-client</artifactId>
         <version>4.3.4</version>
       </dependency>
@@ -11067,12 +11059,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-common</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11108,12 +11094,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-ignite</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-infinispan-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11190,12 +11170,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-coroutines</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-lang-kotlin-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11389,12 +11363,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-templates</artifactId>
         <version>4.3.4</version>
       </dependency>
@@ -11423,12 +11391,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tcp-eventbus-bridge</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-tracing-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -6649,13 +6649,11 @@
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config-common</artifactId>
         <version>1.5.0</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>1.5.0</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
@@ -7175,12 +7173,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-aggregator</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-client</artifactId>
         <version>4.3.4</version>
       </dependency>
@@ -7188,12 +7180,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-common</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7229,12 +7215,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-ignite</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-infinispan-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7311,12 +7291,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-coroutines</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-lang-kotlin-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7510,12 +7484,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-templates</artifactId>
         <version>4.3.4</version>
       </dependency>
@@ -7544,12 +7512,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tcp-eventbus-bridge</artifactId>
         <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-tracing-parent</artifactId>
-        <version>4.3.4</version>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <quarkus-google-cloud-services.version>1.2.2</quarkus-google-cloud-services.version>
         <quarkus-vault.version>2.0.0</quarkus-vault.version>
 
-        <quarkus-platform-bom-generator.version>0.0.63</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.66</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>


### PR DESCRIPTION
When it comes to BOM generation, this release removes unresolvable JAR constraints that in reality appear to be POMs. It also detects POMs that configure JAR relocations and keeps those in the BOMs.