### PR TITLE
Upgrade to the platform generator 0.0.66

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -11098,22 +11098,12 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-aggregator</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-client</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-common</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
@@ -11149,11 +11139,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-ignite</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-infinispan-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
@@ -11230,11 +11215,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-coroutines</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-lang-kotlin-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
@@ -11429,11 +11409,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client-parent</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-templates</artifactId>
         <version>4.3.4</version>
       </dependency>
@@ -11461,11 +11436,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tcp-eventbus-bridge</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-tracing-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -7189,22 +7189,12 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-aggregator</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-client</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-common</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-grpc-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
@@ -7240,11 +7230,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-ignite</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-infinispan-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
@@ -7321,11 +7306,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-coroutines</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-lang-kotlin-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>
@@ -7520,11 +7500,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client-parent</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-templates</artifactId>
         <version>4.3.4</version>
       </dependency>
@@ -7552,11 +7527,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tcp-eventbus-bridge</artifactId>
-        <version>4.3.4</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-tracing-parent</artifactId>
         <version>4.3.4</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <quarkus-vault.version>2.1.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>5.0.0.Beta1</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.62</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.66</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>


### PR DESCRIPTION
When it comes to BOM generation, this release removes unresolvable JAR constraints that in reality appear to be POMs. It also detects POMs that configure JAR relocations and keeps those in the BOMs.