### PR TITLE
Upgrade to platform generator 0.0.69

### DIFF
--- a/generated-platform-project/quarkus-amazon-services/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-amazon-services/properties/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
@@ -101,6 +101,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-blaze-persistence/properties/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-camel/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-camel/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-camel/properties/pom.xml
+++ b/generated-platform-project/quarkus-camel/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-cassandra/properties/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-debezium/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-debezium/descriptor/pom.xml
@@ -101,6 +101,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-debezium/properties/pom.xml
+++ b/generated-platform-project/quarkus-debezium/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-google-cloud-services/properties/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-hazelcast/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-hazelcast/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-hazelcast/properties/pom.xml
+++ b/generated-platform-project/quarkus-hazelcast/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-kogito/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-kogito/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-kogito/properties/pom.xml
+++ b/generated-platform-project/quarkus-kogito/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-maven-plugin/pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/pom.xml
@@ -214,9 +214,9 @@
             <configuration>
               <flattenMode>oss</flattenMode>
               <pomElements>
-                <dependencyManagement>keep</dependencyManagement>
-                <repositories>remove</repositories>
                 <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencyManagement>keep</dependencyManagement>
               </pomElements>
             </configuration>
           </execution>

--- a/generated-platform-project/quarkus-operator-sdk/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-operator-sdk/properties/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-optaplanner/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-optaplanner/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-optaplanner/properties/pom.xml
+++ b/generated-platform-project/quarkus-optaplanner/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
@@ -104,6 +104,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-qpid-jms/properties/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/properties/pom.xml
@@ -53,6 +53,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-universe/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-universe/descriptor/pom.xml
@@ -88,6 +88,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus-universe/properties/pom.xml
+++ b/generated-platform-project/quarkus-universe/properties/pom.xml
@@ -57,6 +57,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus/descriptor/pom.xml
+++ b/generated-platform-project/quarkus/descriptor/pom.xml
@@ -106,6 +106,37 @@
           <skipCategoryCheck>true</skipCategoryCheck>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generated-platform-project/quarkus/properties/pom.xml
+++ b/generated-platform-project/quarkus/properties/pom.xml
@@ -56,6 +56,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+              <pomElements>
+                <build>remove</build>
+                <repositories>remove</repositories>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>remove</dependencyManagement>
+                <mailingLists>remove</mailingLists>
+              </pomElements>
+            </configuration>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <quarkus-vault.version>2.1.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>5.0.0.Beta1</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.66</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.69</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>


### PR DESCRIPTION
This upgrade will flatten the parent POM hierarchy of the generated platform descriptor (json) and properties artifacts.