### PR TITLE
Update to Quarkus Qpid JMS 2.0.0.Alpha2

### DIFF
--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.0.0.Alpha1</version>
+        <version>2.0.0.Alpha2</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.0.0.Alpha1</version>
+        <version>2.0.0.Alpha2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.quarkiverse.artemis</groupId>
       <artifactId>quarkus-test-artemis</artifactId>
-      <version>${quarkus.version}</version>
+      <version>3.0.0.Alpha5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -8025,12 +8025,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.0.0.Alpha1</version>
+        <version>2.0.0.Alpha2</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.0.0.Alpha1</version>
+        <version>2.0.0.Alpha2</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -8429,7 +8429,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sshd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>1.4.0</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.1.0</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>2.0.0.Alpha1</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>2.0.0.Alpha2</quarkus-qpid-jms.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.9.6.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.8</quarkus-blaze-persistence.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 2.0.0.Alpha2, uses Qpid JMS 2.2.0 against Quarkus 3.0.0.Alpha3
