### PR TITLE
Update to Quarkus Qpid JMS 0.42.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -1139,12 +1139,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.41.0</version>
+        <version>0.42.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.41.0</version>
+        <version>0.42.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.41.0</version>
+        <version>0.42.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.41.0</version>
+        <version>0.42.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -12240,12 +12240,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.41.0</version>
+        <version>0.42.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.41.0</version>
+        <version>0.42.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>1.6.1</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.1.0</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>0.41.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.42.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.9.6.Final</debezium-quarkus-outbox.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <quarkus-amazon-services.version>1.6.1</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.1.0</quarkus-config-consul.version>
         <quarkus-qpid-jms.version>0.41.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>1.9.6.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.8</quarkus-blaze-persistence.version>
@@ -359,7 +360,7 @@
                                     </release>
                                     <tests>
                                         <test>
-                                            <artifact>org.amqphub.quarkus:quarkus-qpid-jms-integration-tests:${quarkus-qpid-jms.version}</artifact>
+                                            <artifact>org.amqphub.quarkus:quarkus-qpid-jms-integration-tests:${quarkus-qpid-jms-tests.version}</artifact>
                                         </test>
                                     </tests>
                                 </member>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.42.0, uses Qpid JMS 1.8.0 against Quarkus 2.16.0.Final core.

Same client/quarkus versions as the prior 0.41.0 extension in 2.16.0 but with small change to handle new behaviour on Quarkus main that broke use of the extension in native builds.

The other commit riding along just adds a property to allow using different version of the tests module when that is useful.
