### PR TITLE
Update CI to Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v3
       - name: Get Date
@@ -104,7 +104,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Build with Maven
         run: MAVEN_OPTS=-Xmx3072m && ./mvnw -B clean process-resources --settings .github/mvn-settings.xml
 

--- a/.github/workflows/quarkus-snapshots.yml
+++ b/.github/workflows/quarkus-snapshots.yml
@@ -10,7 +10,7 @@ env:
   LANG: en_US.UTF-8
   ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
   ECOSYSTEM_CI_REPO_FILE: context.yaml
-  JAVA_VERSION: 11
+  JAVA_VERSION: 17
 
   #########################
   # Repo specific setting #


### PR DESCRIPTION
This is done in preparation of the inclusion of Camel Quarkus 3.0.0-M1.

It might be temporary if Camel goes back to Java 11.

/cc @ppalaga 