### PR TITLE
Upgrade to the platform generator 0.0.86

### DIFF
--- a/generated-platform-project/quarkus-dependencies-to-build/pom.xml
+++ b/generated-platform-project/quarkus-dependencies-to-build/pom.xml
@@ -69,11 +69,6 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-bom:${project.version}</bom>
                     <outputFile>../../target/dependencies-to-build/quarkus-bom-deps-to-build.txt</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
                   </configuration>
                 </execution>
                 <execution>
@@ -85,11 +80,6 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-qpid-jms-bom:${project.version}</bom>
                     <outputFile>../../target/dependencies-to-build/quarkus-qpid-jms-bom-deps-to-build.txt</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-qpid-jms-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
                   </configuration>
                 </execution>
                 <execution>
@@ -101,11 +91,6 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-cassandra-bom:${project.version}</bom>
                     <outputFile>../../target/dependencies-to-build/quarkus-cassandra-bom-deps-to-build.txt</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-cassandra-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
                   </configuration>
                 </execution>
                 <execution>
@@ -117,11 +102,6 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-amazon-services-bom:${project.version}</bom>
                     <outputFile>../../target/dependencies-to-build/quarkus-amazon-services-bom-deps-to-build.txt</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-amazon-services-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
                   </configuration>
                 </execution>
                 <execution>
@@ -133,11 +113,6 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-camel-bom:${project.version}</bom>
                     <outputFile>../../target/dependencies-to-build/quarkus-camel-bom-deps-to-build.txt</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-camel-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
                   </configuration>
                 </execution>
               </executions>

--- a/generated-platform-project/quarkus-sbom/pom.xml
+++ b/generated-platform-project/quarkus-sbom/pom.xml
@@ -69,11 +69,7 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-bom:${project.version}</bom>
                     <outputFile>../../target/sbom/quarkus-bom-sbom.json</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
+                    <dependenciesToBuild combine.self="override" />
                   </configuration>
                 </execution>
                 <execution>
@@ -85,11 +81,7 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-qpid-jms-bom:${project.version}</bom>
                     <outputFile>../../target/sbom/quarkus-qpid-jms-bom-sbom.json</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-qpid-jms-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
+                    <dependenciesToBuild combine.self="override" />
                   </configuration>
                 </execution>
                 <execution>
@@ -101,11 +93,7 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-cassandra-bom:${project.version}</bom>
                     <outputFile>../../target/sbom/quarkus-cassandra-bom-sbom.json</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-cassandra-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
+                    <dependenciesToBuild combine.self="override" />
                   </configuration>
                 </execution>
                 <execution>
@@ -117,11 +105,7 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-amazon-services-bom:${project.version}</bom>
                     <outputFile>../../target/sbom/quarkus-amazon-services-bom-sbom.json</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-amazon-services-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
+                    <dependenciesToBuild combine.self="override" />
                   </configuration>
                 </execution>
                 <execution>
@@ -133,11 +117,7 @@
                   <configuration>
                     <bom>io.quarkus.platform:quarkus-camel-bom:${project.version}</bom>
                     <outputFile>../../target/sbom/quarkus-camel-bom-sbom.json</outputFile>
-                    <dependenciesToBuild combine.self="append">
-                      <includeArtifacts combine.children="append">
-                        <artifact>io.quarkus.platform:quarkus-camel-bom::pom:999-SNAPSHOT</artifact>
-                      </includeArtifacts>
-                    </dependenciesToBuild>
+                    <dependenciesToBuild combine.self="override" />
                   </configuration>
                 </execution>
               </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <quarkus-vault.version>3.0.0.Alpha1</quarkus-vault.version>
         <quarkus-operator-sdk.version>5.0.0.Beta1</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.83</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.86</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <useReleaseProfile>true</useReleaseProfile>
@@ -346,7 +346,6 @@
                                         </test>
                                     </tests>
                                 </member>
-                                
                                 <member>
                                     <name>Camel</name>
                                     <bom>org.apache.camel.quarkus:camel-quarkus-bom:${camel-quarkus.version}</bom>
@@ -494,8 +493,6 @@
                                             <excluded>true</excluded>
                                             <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-zendesk:${camel-quarkus-test-list.version}</artifact>
                                         </test>
-                                        
-
                                     </tests>
                                 </member>
                                <!-- <member>


### PR DESCRIPTION
Allows to configure in testing plugins:
* `argLine` using `argLine`, `jvmArgLine` and `nativeArgLine`
* `test` pattern using `testPattern`, `jvmTestPattern` and `nativeTestPattern`

SBOM genertor related enhancements.
