### PR TITLE
CEQ: move test pattern config from the XSL template to the POM config

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
@@ -118,7 +118,6 @@
             <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
             <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
           </systemPropertyVariables>
-          <!--Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4254-->
           <test>!*IT,!CxfSoapClientTest#wsdlUpToDate,!CxfSoapWssClientTest#wsdlUpToDate,!CxfSoapServiceTest#simpleSoapService</test>
         </configuration>
       </plugin>
@@ -170,6 +169,7 @@
                     <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
                     <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
+                  <test>!*IT,!CxfSoapClientTest#wsdlUpToDate,!CxfSoapWssClientTest#wsdlUpToDate,!CxfSoapServiceTest#simpleSoapService</test>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml/pom.xml
@@ -96,7 +96,6 @@
             <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
             <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
           </systemPropertyVariables>
-          <!--Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4255-->
           <test>!*IT,!XmlTest#aggregate,!XmlTest#xsltSchemas</test>
         </configuration>
       </plugin>
@@ -148,6 +147,7 @@
                     <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
                     <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
+                  <test>!*IT,!XmlTest#aggregate,!XmlTest#xsltSchemas</test>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -12,6 +12,8 @@
   <packaging>pom</packaging>
   <name>Quarkus Platform - Camel - Integration Tests - Parent</name>
   <modules>
+    <module>camel-quarkus-integration-test-cxf-soap-grouped</module>
+    <module>camel-quarkus-integration-test-xml</module>
     <module>camel-quarkus-integration-test-kafka-oauth</module>
     <module>camel-quarkus-integration-test-file</module>
     <module>camel-quarkus-integration-test-debezium</module>
@@ -40,7 +42,6 @@
     <module>camel-quarkus-integration-test-crypto</module>
     <module>camel-quarkus-integration-test-csimple</module>
     <module>camel-quarkus-integration-test-csv</module>
-    <module>camel-quarkus-integration-test-cxf-soap-grouped</module>
     <module>camel-quarkus-integration-test-dataformats-json-grouped</module>
     <module>camel-quarkus-integration-test-digitalocean</module>
     <module>camel-quarkus-integration-test-disruptor</module>
@@ -173,7 +174,6 @@
     <module>camel-quarkus-integration-test-vertx-websocket</module>
     <module>camel-quarkus-integration-test-vertx</module>
     <module>camel-quarkus-integration-test-weather</module>
-    <module>camel-quarkus-integration-test-xml</module>
     <module>camel-quarkus-integration-test-xpath</module>
   </modules>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,16 @@
                                     </defaultTestConfig>
                                     <testCatalogArtifact>org.apache.camel.quarkus:camel-quarkus-test-list::xml:${camel-quarkus-test-list.version}</testCatalogArtifact>
                                     <tests>
+                                        <test>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cxf-soap-grouped:${camel-quarkus-test-list.version}</artifact>
+                                            <!--Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4254-->
+                                            <testPattern>!*IT,!CxfSoapClientTest#wsdlUpToDate,!CxfSoapWssClientTest#wsdlUpToDate,!CxfSoapServiceTest#simpleSoapService</testPattern>
+                                        </test>
+                                        <test>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xml:${camel-quarkus-test-list.version}</artifact>
+                                            <!--Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4255-->
+                                            <testPattern>!*IT,!XmlTest#aggregate,!XmlTest#xsltSchemas</testPattern>
+                                        </test>
                                         <test><!-- Workaround for weird issue with shared networking & keycloak container -->
                                             <skip>true</skip>
                                             <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-oauth:${camel-quarkus-test-list.version}</artifact>

--- a/src/main/resources/xslt/camel/test-pom.xsl
+++ b/src/main/resources/xslt/camel/test-pom.xsl
@@ -148,22 +148,4 @@
         </xsl:copy>
     </xsl:template>
 
-    <!-- Disabled because of https://github.com/apache/camel-quarkus/issues/4254 -->
-    <xsl:template match="//pom:configuration[../pom:artifactId/text() = 'maven-surefire-plugin' and /pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-cxf-soap-grouped']">
-        <xsl:copy>
-            <xsl:apply-templates select="@* | node()" />
-            <xsl:comment>Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4254</xsl:comment>
-            <test>!*IT,!CxfSoapClientTest#wsdlUpToDate,!CxfSoapWssClientTest#wsdlUpToDate,!CxfSoapServiceTest#simpleSoapService</test>
-        </xsl:copy>
-    </xsl:template>
-
-    <!-- Disabled because of https://github.com/apache/camel-quarkus/issues/4255 -->
-    <xsl:template match="//pom:configuration[../pom:artifactId/text() = 'maven-surefire-plugin' and /pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-xml']">
-        <xsl:copy>
-            <xsl:apply-templates select="@* | node()" />
-            <xsl:comment>Some tests are disabled because of https://github.com/apache/camel-quarkus/issues/4255</xsl:comment>
-            <test>!*IT,!XmlTest#aggregate,!XmlTest#xsltSchemas</test>
-        </xsl:copy>
-    </xsl:template>
-
 </xsl:stylesheet>


### PR DESCRIPTION
@ppalaga @zbendhiba would you mind moving the test pattern config from the XSLT to the POM?