### PR TITLE
Upgrade Quarkus to 3.0.1

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -4928,17 +4928,17 @@
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-common-rest-client-vertx</artifactId>
-        <version>0.1.13.Final</version>
+        <version>0.1.15.Final</version>
       </dependency>
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-registry-client</artifactId>
-        <version>2.3.1.Final</version>
+        <version>2.4.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
-        <version>2.3.1.Final</version>
+        <version>2.4.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
@@ -5051,63 +5051,63 @@
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>certmanager-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>dekorate-core</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>docker-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>helm-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>kind-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>knative-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>kubernetes-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>openshift-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>option-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>s2i-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>servicebinding-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
@@ -6132,291 +6132,291 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-dev-tools</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-example</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-ssl-ocsp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-classes-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>windows-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-classes</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-aarch_64-fedora</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-x86_64-fedora</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-classes-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-classes-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-rxtx</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-sctp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>
@@ -6432,75 +6432,6 @@
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-contrib-http-util</artifactId>
         <version>0.31.1</version>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry.contrib</groupId>
-        <artifactId>opentelemetry-aws-resources</artifactId>
-        <version>1.23.0-alpha</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry.contrib</groupId>
-        <artifactId>opentelemetry-aws-xray-propagator</artifactId>
-        <version>1.23.0-alpha</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry.contrib</groupId>
-        <artifactId>opentelemetry-aws-xray</artifactId>
-        <version>1.23.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-trace</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry.instrumentation</groupId>
@@ -7692,12 +7623,12 @@
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.gizmo</groupId>
@@ -7713,17 +7644,17 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-core</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-http-core</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-servlet</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -7734,7 +7665,7 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-vertx-backend</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -7745,7 +7676,7 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-websocket-core</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -7756,7 +7687,7 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-websocket-vertx</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -7767,62 +7698,62 @@
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-core</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-generator</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common-types</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-vertx</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.security</groupId>
@@ -7842,567 +7773,567 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-event-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-event-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-event-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arquillian</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-app-model</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-core</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-gradle-resolver</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-runner</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-builder</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-class-change-agent</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-avro-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-avro</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-util</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-csrf-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-csrf-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-development-mode-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-db2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-derby</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-h2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mariadb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mssql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mysql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-oracle</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-postgresql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-registry-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-testing</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-utilities</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-java-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-java-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -8412,118 +8343,118 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-amazon-lambda</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-api</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-codegen</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-inprocess</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-protoc-plugin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-stubs</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-xds</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -8534,167 +8465,167 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hal-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-ide-launcher</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>*</groupId>
@@ -8705,1434 +8636,1434 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-db2-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-db2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-derby-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-derby</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jms-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit4-mock</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-internal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito-config</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-properties</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kind-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kind</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-mock</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panacheql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-project-core-extension-codestarts</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-cache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-cache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-server-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-api</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-schema-registry-devservice-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-schema-registry-devservice</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-webauthn-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-webauthn</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -10143,12 +10074,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -10159,97 +10090,97 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-amqp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-mqtt-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -10269,32 +10200,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -10319,12 +10250,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -10334,32 +10265,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -10369,12 +10300,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -10384,37 +10315,37 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -10424,212 +10355,212 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-amazon-lambda</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-derby</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-google-cloud-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-h2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-infinispan-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-kafka-companion</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-keycloak-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-kubernetes-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-ldap</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-mongodb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-oidc-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-openshift-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-jwt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-oidc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-webauthn</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-vertx</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-transaction-annotations</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-ui-resources</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-latebound-mdc-provider</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.reactivex.rxjava2</groupId>
@@ -10877,107 +10808,107 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-health-check</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-amqp-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-common</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-htdigest</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-htpasswd</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-jdbc</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-jwt</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-ldap</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-mongo</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-oauth2</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-otp</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-properties</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-shiro</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-sql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-webauthn</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-bridge-common</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-cassandra-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-circuit-breaker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-config</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-consul-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-core</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -10988,227 +10919,237 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-db2-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>smallrye-mutiny-vertx-http-proxy</artifactId>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-jdbc-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-json-schema</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-junit5</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-kafka-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mail-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-micrometer-metrics</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mongo-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mqtt</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mssql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mysql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-oracle-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-pg-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-rabbitmq-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-redis-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-runtime</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-backend-consul</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-backend-redis</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-backend-zookeeper</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-consul</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-docker-links</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-docker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-kubernetes</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-zookeeper</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-shell</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-sql-client-templates</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-sql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-stomp</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-tcp-eventbus-bridge</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-uri-template</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-api-service</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-common</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-graphql</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-openapi</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>smallrye-mutiny-vertx-web-proxy</artifactId>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-freemarker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-handlebars</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-jade</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-mvel</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-pebble</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-rocker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-thymeleaf</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-validation</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
@@ -11325,7 +11266,7 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>vertx-mutiny-generator</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.stork</groupId>
@@ -11710,222 +11651,228 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-amqp-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-htdigest</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-htpasswd</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-jdbc</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-jwt</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-ldap</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-mongo</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-oauth2</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-otp</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-auth-parent</artifactId>
+        <version>4.4.1</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-properties</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-shiro</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-sql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-webauthn</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-bridge-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-camel-bridge</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-cassandra-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-circuit-breaker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>processor</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tck-sources</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tck</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-consul</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-git</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-hocon</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-kubernetes-configmap</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-parent</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-redis</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-spring-config-server</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-vault</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-yaml</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-consul-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-consul-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-db2-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -11935,555 +11882,575 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-dropwizard-metrics</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-grpc-context-storage</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-server</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-hazelcast</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-health-check</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-http-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-http-service-factory</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-ignite</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-infinispan</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-io_uring-incubator</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-jdbc-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-json-schema</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5-rx-java2</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5-rx-java3</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5-rx-java</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-kafka-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-groovy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-coroutines</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mail-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mail-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-maven-service-factory</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-micrometer-metrics</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mongo-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mongo-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mqtt</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mssql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mysql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-openapi</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-opentelemetry</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-opentracing</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-oracle-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-pg-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-proton</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rabbitmq-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-reactive-streams</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-redis-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx-java2</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx-java3</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx-java</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-backend-consul</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-backend-redis</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-backend-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-consul</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-docker-links</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-docker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-kubernetes</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-parent</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-factory</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-shell</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sockjs-service-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-templates</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stomp</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sync</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tcp-eventbus-bridge</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-unit</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-uri-template</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-api-contract</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-api-service</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-graphql</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-openapi-router</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-openapi</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-parent</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-sstore-cookie</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-sstore-infinispan</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-sstore-redis</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-handlebars</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-handlebars</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-httl</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-httl</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-httl</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jade</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jade</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jte</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jte</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jte</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-mvel</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-mvel</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-pebble</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-pebble</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rocker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rocker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rocker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rythm</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rythm</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rythm</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-thymeleaf</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-thymeleaf</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-validation</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-zipkin</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>jakarta.activation</groupId>
@@ -20033,7 +20000,7 @@
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.osgi</groupId>
@@ -20144,7 +20111,7 @@
       <dependency>
         <groupId>org.eclipse</groupId>
         <artifactId>yasson</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.ehcache</groupId>
@@ -20253,12 +20220,12 @@
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-community-dialects</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss</groupId>
@@ -20269,22 +20236,22 @@
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-envers</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-graalvm</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-jpamodelgen</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.reactive</groupId>
         <artifactId>hibernate-reactive-core</artifactId>
-        <version>2.0.0.Beta1</version>
+        <version>2.0.0.CR1</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.search</groupId>
@@ -20340,83 +20307,83 @@
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-processor</artifactId>
-        <version>4.6.1.Final</version>
+        <version>4.6.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-types</artifactId>
-        <version>4.6.1.Final</version>
+        <version>4.6.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream</artifactId>
-        <version>4.6.1.Final</version>
+        <version>4.6.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-api</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-client-hotrod-jakarta</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons-jakarta</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons-test</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-component-annotations</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-objectfilter</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query-dsl</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-client</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-server</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-testdriver-core</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId>
@@ -21218,7 +21185,7 @@
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-adapter-core</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21229,12 +21196,12 @@
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-adapter-spi</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-admin-client-jakarta</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -21245,17 +21212,17 @@
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-client</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-common</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-core</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
@@ -21475,7 +21442,7 @@
       <dependency>
         <groupId>org.mongodb</groupId>
         <artifactId>mongodb-crypt</artifactId>
-        <version>1.7.1</version>
+        <version>1.7.3</version>
       </dependency>
       <dependency>
         <groupId>org.mongodb</groupId>
@@ -21913,7 +21880,7 @@
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>importmap</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>

--- a/generated-platform-project/quarkus-universe/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus-universe/descriptor/src/main/resources/overrides.json
@@ -1,6 +1,6 @@
 {
   "metadata" : {
-    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:3.0.0.Final" ],
+    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:3.0.1.Final" ],
     "project" : {
       "default-codestart" : "resteasy-reactive",
       "properties" : {
@@ -11,16 +11,16 @@
         "kotlin-version" : "1.8.10",
         "scala-version" : "2.13.8",
         "scala-plugin-version" : "4.8.1",
-        "quarkus-core-version" : "3.0.0.Final",
+        "quarkus-core-version" : "3.0.1.Final",
         "maven-plugin-groupId" : "io.quarkus",
         "maven-plugin-artifactId" : "quarkus-maven-plugin",
-        "maven-plugin-version" : "3.0.0.Final",
+        "maven-plugin-version" : "3.0.1.Final",
         "gradle-plugin-id" : "io.quarkus",
-        "gradle-plugin-version" : "3.0.0.Final",
+        "gradle-plugin-version" : "3.0.1.Final",
         "supported-maven-versions" : "[3.6.3,)",
         "proposed-maven-version" : "3.8.8",
         "maven-wrapper-version" : "3.2.0",
-        "gradle-wrapper-version" : "8.0.2",
+        "gradle-wrapper-version" : "8.1",
         "minimum-java-version" : "11",
         "recommended-java-version" : "17"
       }

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -948,78 +948,78 @@
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-common-rest-client-vertx</artifactId>
-        <version>0.1.13.Final</version>
+        <version>0.1.15.Final</version>
       </dependency>
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-registry-client</artifactId>
-        <version>2.3.1.Final</version>
+        <version>2.4.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
-        <version>2.3.1.Final</version>
+        <version>2.4.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>certmanager-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>dekorate-core</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>docker-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>helm-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>kind-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>knative-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>kubernetes-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>openshift-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>option-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>s2i-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>
         <artifactId>servicebinding-annotations</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
         <classifier>noapt</classifier>
       </dependency>
       <dependency>
@@ -2008,360 +2008,291 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-dev-tools</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-example</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-ssl-ocsp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-classes-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>windows-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-classes</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-aarch_64-fedora</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-x86_64-fedora</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>2.0.56.Final</version>
+        <version>2.0.59.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-classes-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-classes-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-rxtx</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-sctp</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>4.1.87.Final</version>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>4.1.87.Final</version>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry.contrib</groupId>
-        <artifactId>opentelemetry-aws-resources</artifactId>
-        <version>1.23.0-alpha</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry.contrib</groupId>
-        <artifactId>opentelemetry-aws-xray-propagator</artifactId>
-        <version>1.23.0-alpha</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>io.opentelemetry.contrib</groupId>
-        <artifactId>opentelemetry-aws-xray</artifactId>
-        <version>1.23.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-trace</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>4.1.90.Final</version>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry.instrumentation</groupId>
@@ -3027,12 +2958,12 @@
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>
         <artifactId>arc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.gizmo</groupId>
@@ -3048,17 +2979,17 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-core</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-http-core</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-servlet</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -3069,7 +3000,7 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-vertx-backend</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -3080,7 +3011,7 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-websocket-core</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -3091,7 +3022,7 @@
       <dependency>
         <groupId>io.quarkus.http</groupId>
         <artifactId>quarkus-http-websocket-vertx</artifactId>
-        <version>5.0.1.Final</version>
+        <version>5.0.2.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -3102,62 +3033,62 @@
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-core</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.qute</groupId>
         <artifactId>qute-generator</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common-types</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-processor</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive-vertx</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.resteasy.reactive</groupId>
         <artifactId>resteasy-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.security</groupId>
@@ -3177,567 +3108,567 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-agroal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-event-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http-event-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest-event-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-rest</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda-xray</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-amazon-lambda</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apache-httpclient</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-avro</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-apicurio-registry-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-arquillian</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-avro</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-awt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-azure-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-app-model</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-core</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-gradle-resolver</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bootstrap-runner</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-builder</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-cache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-caffeine</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-class-change-agent</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-config-yaml</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-avro-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-avro</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-confluent-registry-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-buildpack</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-docker</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-jib</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-openshift</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-s2i</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image-util</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-container-image</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-core</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-credentials</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-csrf-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-csrf-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-datasource</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-development-mode-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-db2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-derby</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-h2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mariadb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mssql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-mysql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-oracle</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devservices-postgresql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-registry-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-testing</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-utilities</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-java-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-java-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elasticsearch-rest-high-level-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-jdbc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-ldap</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-oauth2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security-properties-file</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-elytron-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-flyway</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -3747,118 +3678,118 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-amazon-lambda</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-google-cloud-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-knative-events</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-funqy-server-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-google-cloud-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-api</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-codegen</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-inprocess</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-protoc-plugin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-stubs</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc-xds</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-grpc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -3869,167 +3800,167 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hal-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-envers</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-orm</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-coordination-outbox-polling</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-search-orm-elasticsearch</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-hibernate-validator</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-ide-launcher</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>*</groupId>
@@ -4040,1434 +3971,1434 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-infinispan-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-info</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jacoco</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaeger</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-client-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jaxrs-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-db2-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-db2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-derby-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-derby</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-h2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mariadb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mssql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-mysql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-oracle</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jdbc-postgresql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jms-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-jsonp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit4-mock</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-internal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito-config</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-mockito</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5-properties</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kafka-streams</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-admin-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-keycloak-authorization</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kind-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kind</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-internal</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-config</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-service-binding</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-kubernetes</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase-mongodb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-liquibase</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-gelf</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-logging-json</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mailer</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-micrometer</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-minikube</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mongodb-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny-reactive-streams-operators</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-mutiny</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-jta</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-lra</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-narayana-stm</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-netty</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-filter</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client-reactive-filter</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc-token-propagation</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-oidc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-openshift</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-opentelemetry</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-hibernate-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panache-mock</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-panacheql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-picocli</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-project-core-extension-codestarts</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-quartz</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-qute</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-datasource</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-db2-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mssql-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-mysql-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-oracle-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-pg-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-reactive-routes</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-cache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-cache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-redis-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-config</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-mutiny</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-kotlin-serialization</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-rest-data-panache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-links</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-multipart</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-mutiny</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-qute</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jaxb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-jsonb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin-serialization</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-links</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-qute</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-server-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-servlet</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive-spi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy-server-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-resteasy</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scala</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-api</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-scheduler</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-schema-registry-devservice-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-schema-registry-devservice</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-jpa</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-webauthn-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security-webauthn</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-context-propagation</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-graphql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-health</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-build</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-jwt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-metrics</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-common-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -5478,12 +5409,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-openapi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -5494,97 +5425,97 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-opentracing</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-amqp-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-kotlin</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-mqtt-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-streams-operators</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-reactive-type-converters</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-smallrye-stork</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5604,32 +5535,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-boot-properties</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cache</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-cloud-config-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5654,12 +5585,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-jpa</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5669,32 +5600,32 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-data-rest</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-di</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-scheduled</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5704,12 +5635,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5719,37 +5650,37 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-classic</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web-resteasy-reactive</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-web</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
@@ -5759,212 +5690,212 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-swagger-ui</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-amazon-lambda</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-common</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-derby</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-google-cloud-functions</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-h2</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-infinispan-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-kafka-companion</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-keycloak-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-kubernetes-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-ldap</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-mongodb</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-oidc-server</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-openshift-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-jwt</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-oidc</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security-webauthn</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-security</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-vertx</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-transaction-annotations</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-undertow</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-graphql</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-runtime-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-console-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-ui-resources</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http-dev-ui-spi</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-http</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx-latebound-mdc-provider</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-vertx</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-webjars-locator</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-client</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets-deployment</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-websockets</artifactId>
-        <version>3.0.0.Final</version>
+        <version>3.0.1.Final</version>
       </dependency>
       <dependency>
         <groupId>io.reactivex.rxjava2</groupId>
@@ -6212,107 +6143,107 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-health-check</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-amqp-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-common</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-htdigest</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-htpasswd</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-jdbc</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-jwt</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-ldap</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-mongo</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-oauth2</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-otp</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-properties</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-shiro</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-sql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-webauthn</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-bridge-common</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-cassandra-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-circuit-breaker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-config</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-consul-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-core</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -6323,227 +6254,237 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-db2-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>smallrye-mutiny-vertx-http-proxy</artifactId>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-jdbc-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-json-schema</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-junit5</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-kafka-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mail-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-micrometer-metrics</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mongo-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mqtt</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mssql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-mysql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-oracle-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-pg-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-rabbitmq-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-redis-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-runtime</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-backend-consul</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-backend-redis</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-backend-zookeeper</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-consul</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-docker-links</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-docker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-kubernetes</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery-bridge-zookeeper</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-service-discovery</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-shell</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-sql-client-templates</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-sql-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-stomp</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-tcp-eventbus-bridge</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-uri-template</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-api-service</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-common</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-graphql</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-openapi</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>smallrye-mutiny-vertx-web-proxy</artifactId>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-freemarker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-handlebars</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-jade</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-mvel</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-pebble</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-rocker</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-templ-thymeleaf</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-validation</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
@@ -6660,7 +6601,7 @@
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>vertx-mutiny-generator</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.stork</groupId>
@@ -7045,222 +6986,228 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-amqp-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-htdigest</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-htpasswd</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-jdbc</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-jwt</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-ldap</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-mongo</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-oauth2</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-otp</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-auth-parent</artifactId>
+        <version>4.4.1</version>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-properties</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-shiro</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-sql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth-webauthn</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-auth</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-bridge-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-camel-bridge</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-cassandra-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-circuit-breaker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>processor</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tck-sources</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tck</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-codegen</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-consul</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-git</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-hocon</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-kubernetes-configmap</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-parent</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-redis</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-spring-config-server</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-vault</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-yaml</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-config</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-consul-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-consul-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-core</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-db2-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -7270,555 +7217,575 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-dropwizard-metrics</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-grpc-context-storage</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc-server</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-grpc</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-hazelcast</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-health-check</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-http-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-http-service-factory</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-ignite</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-infinispan</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-io_uring-incubator</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-jdbc-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-json-schema</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5-rx-java2</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5-rx-java3</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5-rx-java</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-junit5</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-kafka-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-groovy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin-coroutines</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-lang-kotlin</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mail-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mail-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-maven-service-factory</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-micrometer-metrics</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mongo-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mongo-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mqtt</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mssql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-mysql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-openapi</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-opentelemetry</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-opentracing</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-oracle-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-pg-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-proton</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rabbitmq-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-reactive-streams</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-redis-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx-java2</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx-java3</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx-java</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-rx</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-backend-consul</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-backend-redis</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-backend-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-consul</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-docker-links</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-docker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-kubernetes</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-bridge-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-parent</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-factory</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-shell</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sockjs-service-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client-templates</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stomp</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sync</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-tcp-eventbus-bridge</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-unit</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-uri-template</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-api-contract</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-api-service</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-client</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-common</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-graphql</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-openapi-router</artifactId>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-openapi</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-parent</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-proxy</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-sstore-cookie</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-sstore-infinispan</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-sstore-redis</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-handlebars</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-handlebars</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-httl</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-httl</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-httl</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jade</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jade</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jte</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jte</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-jte</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-mvel</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-mvel</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-pebble</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-pebble</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rocker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rocker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rocker</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rythm</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rythm</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-rythm</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-thymeleaf</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-thymeleaf</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>shaded</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-validation</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-zipkin</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-zookeeper</artifactId>
-        <version>4.3.7</version>
+        <version>4.4.1</version>
       </dependency>
       <dependency>
         <groupId>jakarta.activation</groupId>
@@ -8446,7 +8413,7 @@
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.osgi</groupId>
@@ -8557,7 +8524,7 @@
       <dependency>
         <groupId>org.eclipse</groupId>
         <artifactId>yasson</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.elasticsearch.client</groupId>
@@ -8650,12 +8617,12 @@
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-community-dialects</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss</groupId>
@@ -8666,22 +8633,22 @@
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-envers</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-graalvm</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-jpamodelgen</artifactId>
-        <version>6.2.0.Final</version>
+        <version>6.2.1.Final</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.reactive</groupId>
         <artifactId>hibernate-reactive-core</artifactId>
-        <version>2.0.0.Beta1</version>
+        <version>2.0.0.CR1</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.search</groupId>
@@ -8737,83 +8704,83 @@
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-processor</artifactId>
-        <version>4.6.1.Final</version>
+        <version>4.6.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-types</artifactId>
-        <version>4.6.1.Final</version>
+        <version>4.6.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream</artifactId>
-        <version>4.6.1.Final</version>
+        <version>4.6.2.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-api</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-client-hotrod-jakarta</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons-jakarta</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-commons-test</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-component-annotations</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-objectfilter</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query-dsl</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-query</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-client</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-server</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-hotrod</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-server-testdriver-core</artifactId>
-        <version>14.0.7.Final</version>
+        <version>14.0.8.Final</version>
       </dependency>
       <dependency>
         <groupId>org.jacoco</groupId>
@@ -9585,7 +9552,7 @@
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-adapter-core</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -9596,12 +9563,12 @@
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-adapter-spi</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-admin-client-jakarta</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -9612,17 +9579,17 @@
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-client</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-common</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-core</artifactId>
-        <version>21.0.1</version>
+        <version>21.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.liquibase.ext</groupId>
@@ -9713,7 +9680,7 @@
       <dependency>
         <groupId>org.mongodb</groupId>
         <artifactId>mongodb-crypt</artifactId>
-        <version>1.7.1</version>
+        <version>1.7.3</version>
       </dependency>
       <dependency>
         <groupId>org.mongodb</groupId>
@@ -10146,7 +10113,7 @@
       <dependency>
         <groupId>org.mvnpm</groupId>
         <artifactId>importmap</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
       </dependency>
       <dependency>
         <groupId>org.mvnpm</groupId>

--- a/generated-platform-project/quarkus/descriptor/src/main/resources/overrides.json
+++ b/generated-platform-project/quarkus/descriptor/src/main/resources/overrides.json
@@ -1,6 +1,6 @@
 {
   "metadata" : {
-    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:3.0.0.Final" ],
+    "codestarts-artifacts" : [ "io.quarkus:quarkus-project-core-extension-codestarts::jar:3.0.1.Final" ],
     "project" : {
       "default-codestart" : "resteasy-reactive",
       "properties" : {
@@ -11,16 +11,16 @@
         "kotlin-version" : "1.8.10",
         "scala-version" : "2.13.8",
         "scala-plugin-version" : "4.8.1",
-        "quarkus-core-version" : "3.0.0.Final",
+        "quarkus-core-version" : "3.0.1.Final",
         "maven-plugin-groupId" : "${project.groupId}",
         "maven-plugin-artifactId" : "quarkus-maven-plugin",
         "maven-plugin-version" : "${project.version}",
         "gradle-plugin-id" : "io.quarkus",
-        "gradle-plugin-version" : "3.0.0.Final",
+        "gradle-plugin-version" : "3.0.1.Final",
         "supported-maven-versions" : "[3.6.3,)",
         "proposed-maven-version" : "3.8.8",
         "maven-wrapper-version" : "3.2.0",
-        "gradle-wrapper-version" : "8.0.2",
+        "gradle-wrapper-version" : "8.1",
         "minimum-java-version" : "11",
         "recommended-java-version" : "17"
       }

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <graalvmHome>${env.GRAALVM_HOME}</graalvmHome>
         <postgres.url>jdbc:postgresql:hibernate_orm_test</postgres.url>
 
-        <quarkus.version>3.0.0.Final</quarkus.version>
+        <quarkus.version>3.0.1.Final</quarkus.version>
         <quarkus-bom.version>${quarkus.version}</quarkus-bom.version>
 
         <camel-quarkus.version>3.0.0-M1</camel-quarkus.version>
@@ -82,7 +82,7 @@
         <quarkus-vault.version>3.0.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>6.0.0</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.87</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.88</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>


### PR DESCRIPTION
Also upgrade the platform generator to 0.0.88 that filters out test scoped dependencies.

Supersedes https://github.com/quarkusio/quarkus-platform/pull/822