### PR TITLE
Update to Quarkus Qpid JMS 0.43.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -1139,12 +1139,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.42.0</version>
+        <version>0.43.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.42.0</version>
+        <version>0.43.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.42.0</version>
+        <version>0.43.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.42.0</version>
+        <version>0.43.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
@@ -25,14 +25,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkiverse.artemis</groupId>
-      <artifactId>quarkus-test-artemis</artifactId>
-      <version>1.0.5</version>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-server</artifactId>
+      <version>2.28.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-amqp-protocol</artifactId>
+      <version>2.28.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jackson</artifactId>
+      <artifactId>quarkus-test-common</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -66,11 +72,6 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>commons-logging-jboss-logging</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -13116,12 +13116,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.42.0</version>
+        <version>0.43.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.42.0</version>
+        <version>0.43.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>1.4.0</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.1.0</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>0.42.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.43.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>2.1.2.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.43.0, uses Qpid JMS 1.8.0 against Quarkus 2.16.6.Final

Its the same Qpid JMS client version as used before, we only added an option to the extension itself (disabled by default, so behaviour is unchanged from before unless asked) to enable it to allow [quarkus-pooled-jms](https://github.com/quarkiverse/quarkus-pooled-jms) to supply pooling for the injected ConnectionFactory.