### PR TITLE
Define system property for optaplanner test

### DIFF
--- a/generated-platform-project/quarkus-optaplanner/integration-tests/optaplanner-quarkus-devui-integration-test/pom.xml
+++ b/generated-platform-project/quarkus-optaplanner/integration-tests/optaplanner-quarkus-devui-integration-test/pom.xml
@@ -92,6 +92,9 @@
           <dependenciesToScan>
             <dependency>org.optaplanner:optaplanner-quarkus-devui-integration-test</dependency>
           </dependenciesToScan>
+          <systemPropertyVariables>
+            <dev.iu.root>/q/dev</dev.iu.root>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>
@@ -117,6 +120,7 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                    <dev.iu.root>/q/dev</dev.iu.root>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,9 @@
                                         </test>
                                         <test>
                                             <artifact>org.optaplanner:optaplanner-quarkus-devui-integration-test:${optaplanner-quarkus.version}</artifact>
+                                            <systemProperties>
+                                                <dev.iu.root>/q/dev</dev.iu.root>
+                                            </systemProperties>
                                         </test>
                                         <test>
                                             <artifact>org.optaplanner:optaplanner-quarkus-jackson-integration-test:${optaplanner-quarkus.version}</artifact>


### PR DESCRIPTION
Fixes the devui integration test for OptaPlanner; required by https://github.com/quarkusio/quarkus-platform/pull/829.