### PR TITLE
[2.16] Update to Quarkus Qpid JMS 0.44.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -1139,12 +1139,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.43.0</version>
+        <version>0.44.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.43.0</version>
+        <version>0.44.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -11009,7 +11009,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.43.0</version>
+        <version>0.44.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.43.0</version>
+        <version>0.44.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -13116,12 +13116,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.43.0</version>
+        <version>0.44.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.43.0</version>
+        <version>0.44.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -23470,7 +23470,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>1.4.0</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.1.0</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>0.43.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.44.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>2.1.2.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.44.0, uses Qpid JMS 1.9.0 against Quarkus 2.16.7.Final