### PR TITLE
Update to Quarkus Qpid JMS 2.2.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -896,12 +896,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -6776,7 +6776,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -12642,12 +12642,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -18927,7 +18927,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>2.0.1</quarkus-amazon-services.version>
         <quarkus-config-consul.version>2.0.1</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>2.1.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>2.2.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>2.2.0.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 2.2.0, uses Qpid JMS 2.3.0 against Quarkus 3.1.0.Final