### PR TITLE
[2.16] Update to Quarkus Qpid JMS 0.45.0

### DIFF
--- a/.github/ci-prerequisites.sh
+++ b/.github/ci-prerequisites.sh
@@ -1,0 +1,45 @@
+# Reclaim disk space, otherwise we have too little free space at the start of a job
+#
+# Numbers as of 2023-01-06:
+#
+# $ df -h
+# Filesystem      Size  Used Avail Use% Mounted on
+# /dev/root        84G   48G   36G  58% /
+# tmpfs           3.4G  172K  3.4G   1% /dev/shm
+# tmpfs           1.4G  1.1M  1.4G   1% /run
+# tmpfs           5.0M     0  5.0M   0% /run/lock
+# /dev/sda15      105M  5.3M  100M   5% /boot/efi
+# /dev/sdb1        14G  4.1G  9.0G  31% /mnt
+# tmpfs           695M   12K  695M   1% /run/user/1001
+#
+# $ docker images
+# REPOSITORY       TAG         IMAGE ID       CREATED        SIZE
+# node             14-alpine   b4fb2cece133   3 weeks ago    123MB
+# node             16-alpine   bb97fd22e6f8   3 weeks ago    118MB
+# node             18-alpine   6d7b7852bcd3   3 weeks ago    169MB
+# ubuntu           22.04       6b7dfa7e8fdb   3 weeks ago    77.8MB
+# ubuntu           20.04       d5447fc01ae6   3 weeks ago    72.8MB
+# ubuntu           18.04       251b86c83674   3 weeks ago    63.1MB
+# node             14          c08c80352dd3   4 weeks ago    915MB
+# node             16          993a4cf9c1e8   4 weeks ago    910MB
+# node             18          209311a7c0e2   4 weeks ago    991MB
+# buildpack-deps   buster      623b2dda3870   4 weeks ago    803MB
+# buildpack-deps   bullseye    8cbf14941d59   4 weeks ago    835MB
+# debian           10          528ac3ebe420   4 weeks ago    114MB
+# debian           11          291bf168077c   4 weeks ago    124MB
+# alpine           3.16        bfe296a52501   7 weeks ago    5.54MB
+# moby/buildkit    latest      383075513bdc   8 weeks ago    142MB
+# alpine           3.14        dd53f409bf0b   4 months ago   5.6MB
+# alpine           3.15        c4fc93816858   4 months ago   5.58MB
+
+time docker rmi node:14 node:16 node:18 node:14-alpine node:16-alpine node:18-alpine buildpack-deps:buster buildpack-deps:bullseye
+# That is 979M
+time sudo rm -rf /usr/share/dotnet
+# That is 1.7G
+time sudo rm -rf /usr/share/swift
+# Remove Android
+time sudo rm -rf /usr/local/lib/android
+# Remove Haskell
+time sudo rm -rf /opt/ghc
+# Remove pipx
+time sudo rm -rf /opt/pipx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v3
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
       - name: Get Date
         id: get-date
         run: |

--- a/.github/workflows/quarkus-snapshots.yml
+++ b/.github/workflows/quarkus-snapshots.yml
@@ -25,6 +25,15 @@ jobs:
     if: github.actor == 'quarkusbot'
 
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: current-repo
+          ref: main
+
+      - name: Reclaim Disk Space
+        run: current-repo/.github/ci-prerequisites.sh
+
       - name: Install yq
         run: sudo add-apt-repository ppa:rmescandon/yq && sudo apt update && sudo apt install yq -y
 
@@ -33,12 +42,6 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
-
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          path: current-repo
-          ref: main
 
       - name: Checkout Ecosystem
         uses: actions/checkout@v3

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -1139,12 +1139,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.44.0</version>
+        <version>0.45.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.44.0</version>
+        <version>0.45.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -11009,7 +11009,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.44.0</version>
+        <version>0.45.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.44.0</version>
+        <version>0.45.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -13140,12 +13140,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>0.44.0</version>
+        <version>0.45.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>0.44.0</version>
+        <version>0.45.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -23494,7 +23494,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
              as they might require adjustments. -->
         <quarkus-amazon-services.version>1.4.0</quarkus-amazon-services.version>
         <quarkus-config-consul.version>1.1.0</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>0.44.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>0.45.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>2.1.2.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 0.45.0, uses Qpid JMS 1.10.0 against Quarkus 2.16.7.Final