### PR TITLE
Update to Quarkus Qpid JMS 2.3.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -907,12 +907,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -6941,7 +6941,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
@@ -14,12 +14,12 @@
     <dependency>
       <groupId>org.amqphub.quarkus</groupId>
       <artifactId>quarkus-qpid-jms-integration-tests</artifactId>
-      <version>${quarkus-qpid-jms.version}</version>
+      <version>${quarkus-amazon-services.version}</version>
     </dependency>
     <dependency>
       <groupId>org.amqphub.quarkus</groupId>
       <artifactId>quarkus-qpid-jms-integration-tests</artifactId>
-      <version>${quarkus-qpid-jms.version}</version>
+      <version>${quarkus-amazon-services.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -150,7 +150,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.amqphub.quarkus:quarkus-qpid-jms-integration-tests:${quarkus-qpid-jms.version}</appArtifact>
+                  <appArtifact>org.amqphub.quarkus:quarkus-qpid-jms-integration-tests:${quarkus-amazon-services.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -12841,12 +12841,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -19285,7 +19285,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <quarkus-amazon-services.version>2.3.0</quarkus-amazon-services.version>
         <quarkus-cxf.version>2.1.0</quarkus-cxf.version>
         <quarkus-config-consul.version>2.0.1</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>2.2.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>2.3.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>2.2.0.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 2.3.0, uses Qpid JMS 2.4.0 against Quarkus 3.2.0.Final