### PR TITLE
[2.16.x] Disable Camel JMS and JTA tests

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-jms-artemis-client</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-jms-artemis-client</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -186,6 +189,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-artemis-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-jms-qpid-amqp-client</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-jms-qpid-amqp-client</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -180,6 +183,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-qpid-amqp-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
@@ -8,6 +8,9 @@
   </parent>
   <artifactId>camel-quarkus-integration-test-jta</artifactId>
   <name>Quarkus Platform - Camel - Integration Tests - camel-quarkus-integration-test-jta</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
@@ -165,6 +168,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jta:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -18,10 +18,13 @@
     <module>camel-quarkus-integration-test-kudu</module>
     <module>camel-quarkus-integration-test-tika</module>
     <module>camel-quarkus-integration-test-lra</module>
+    <module>camel-quarkus-integration-test-jms-artemis-client</module>
+    <module>camel-quarkus-integration-test-jms-qpid-amqp-client</module>
     <module>camel-quarkus-integration-test-sjms-artemis-client</module>
     <module>camel-quarkus-integration-test-sjms-qpid-amqp-client</module>
     <module>camel-quarkus-integration-test-sjms2-artemis-client</module>
     <module>camel-quarkus-integration-test-sjms2-qpid-amqp-client</module>
+    <module>camel-quarkus-integration-test-jta</module>
     <module>camel-quarkus-integration-test-activemq</module>
     <module>camel-quarkus-integration-test-amqp</module>
     <module>camel-quarkus-integration-test-arangodb</module>
@@ -89,8 +92,6 @@
     <module>camel-quarkus-integration-test-jdbc</module>
     <module>camel-quarkus-integration-test-jfr</module>
     <module>camel-quarkus-integration-test-jira</module>
-    <module>camel-quarkus-integration-test-jms-artemis-client</module>
-    <module>camel-quarkus-integration-test-jms-qpid-amqp-client</module>
     <module>camel-quarkus-integration-test-jolt</module>
     <module>camel-quarkus-integration-test-jpa</module>
     <module>camel-quarkus-integration-test-jq</module>
@@ -101,7 +102,6 @@
     <module>camel-quarkus-integration-test-json-validator</module>
     <module>camel-quarkus-integration-test-jsonata</module>
     <module>camel-quarkus-integration-test-jsonpath</module>
-    <module>camel-quarkus-integration-test-jta</module>
     <module>camel-quarkus-integration-test-kafka-sasl-ssl</module>
     <module>camel-quarkus-integration-test-kafka-sasl</module>
     <module>camel-quarkus-integration-test-kafka-ssl</module>

--- a/pom.xml
+++ b/pom.xml
@@ -487,6 +487,14 @@
                                         <!-- Workaround issues with available disk space for the Artemis broker -->
                                         <test>
                                             <skip>true</skip>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-artemis-client:${camel-quarkus-test-list.version}</artifact>
+                                        </test>
+                                        <test>
+                                            <skip>true</skip>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-qpid-amqp-client:${camel-quarkus-test-list.version}</artifact>
+                                        </test>
+                                        <test>
+                                            <skip>true</skip>
                                             <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms-artemis-client:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                         <test>
@@ -500,6 +508,10 @@
                                         <test>
                                             <skip>true</skip>
                                             <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms2-qpid-amqp-client:${camel-quarkus-test-list.version}</artifact>
+                                        </test>
+                                        <test>
+                                            <skip>true</skip>
+                                            <artifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jta:${camel-quarkus-test-list.version}</artifact>
                                         </test>
                                     </tests>
                                     <dependencyManagement>


### PR DESCRIPTION
Follow up on #867. Looks like I missed a few tests that have been causing issues for other PRs.