### PR TITLE
Remove redundant Camel Quarkus integration test XSLT transforms

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-amqp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-amqp/pom.xml
@@ -105,33 +105,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-amqp</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -156,9 +130,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-arangodb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-arangodb/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-arangodb</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-atlasmap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-atlasmap/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-atlasmap</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-avro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-avro/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-avro</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-grouped/pom.xml
@@ -136,33 +136,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -187,9 +161,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-quarkus-client-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-quarkus-client-grouped/pom.xml
@@ -125,33 +125,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2-quarkus-client-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -176,9 +150,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2/pom.xml
@@ -58,33 +58,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -109,9 +83,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
@@ -102,33 +102,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-azure-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -153,9 +127,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-base64/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-base64/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-base64</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bean-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bean-validator/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-bean-validator</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bindy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bindy/pom.xml
@@ -80,33 +80,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-bindy</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -131,9 +105,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-box/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-box/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-box</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-braintree/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-braintree/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-braintree</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-caffeine/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-caffeine/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-caffeine</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cassandraql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cassandraql/pom.xml
@@ -129,33 +129,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-cassandraql</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -180,9 +154,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cbor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cbor/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-cbor</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-compression-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-compression-grouped/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-compression-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-consul/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-consul/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-consul</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-core-discovery-disabled/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-core-discovery-disabled/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-core-discovery-disabled</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-couchdb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-couchdb/pom.xml
@@ -106,33 +106,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-couchdb</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -157,9 +131,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-crypto</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csimple/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csimple/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-csimple</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csv/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csv/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-csv</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
@@ -113,33 +113,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-cxf-soap-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -164,9 +138,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformat/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformat/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-dataformat</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformats-json-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformats-json-grouped/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-dataformats-json-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-datasonnet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-datasonnet/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-datasonnet</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
@@ -155,33 +155,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-debezium</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -206,9 +180,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debug/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debug/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-debug</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-digitalocean/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-digitalocean/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-digitalocean</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-disruptor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-disruptor/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-disruptor</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dropbox/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dropbox/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-dropbox</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-exec/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-exec/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-exec</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fhir/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fhir/pom.xml
@@ -107,33 +107,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-fhir</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -158,9 +132,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-file/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-file/pom.xml
@@ -88,33 +88,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-file</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -139,9 +113,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-flatpack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-flatpack/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-flatpack</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fop/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fop/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-fop</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-foundation-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-foundation-grouped/pom.xml
@@ -107,33 +107,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-foundation-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -158,9 +132,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-freemarker/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-freemarker/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-freemarker</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
@@ -127,33 +127,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-ftp</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -178,9 +152,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-geocoder/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-geocoder/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-geocoder</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-git/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-git/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-git</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-github/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-github/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-github</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-bigquery/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-bigquery/pom.xml
@@ -97,33 +97,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-google-bigquery</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -148,9 +122,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-google-pubsub</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-storage/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-storage/pom.xml
@@ -107,33 +107,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-google-storage</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -158,9 +132,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-google</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-graphql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-graphql/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-graphql</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grok/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grok/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-grok</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy/pom.xml
@@ -69,33 +69,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-groovy</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -120,9 +94,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grpc/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grpc/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-grpc</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-headersmap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-headersmap/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-headersmap</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hl7/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hl7/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-hl7</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http/pom.xml
@@ -107,33 +107,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-http</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -158,9 +132,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-common/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-common/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan-common</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-quarkus-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-quarkus-client/pom.xml
@@ -108,33 +108,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan-quarkus-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -159,9 +133,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan/pom.xml
@@ -108,33 +108,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -159,9 +133,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-influxdb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-influxdb/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-influxdb</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-avro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-avro/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jackson-avro</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-protobuf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-protobuf/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jackson-protobuf</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-java-joor-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-java-joor-dsl/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-java-joor-dsl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jaxb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jaxb/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jaxb</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jcache/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jcache/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jcache</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jdbc/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jdbc/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jdbc</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jfr/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jfr/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jfr</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jira/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jira/pom.xml
@@ -102,33 +102,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jira</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -153,9 +127,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
@@ -111,33 +111,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-artemis-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -162,9 +136,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-ibmmq-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-ibmmq-client/pom.xml
@@ -115,33 +115,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-ibmmq-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -166,9 +140,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
@@ -105,33 +105,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-qpid-amqp-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -156,9 +130,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jolt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jolt/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jolt</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-joor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-joor/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-joor</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jpa/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jpa/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jpa</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jq/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jq</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
@@ -91,11 +91,6 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -118,27 +113,6 @@
                   <includes>**/*.mjs</includes>
                 </artifactItem>
               </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
             </configuration>
           </execution>
         </executions>
@@ -166,9 +140,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsch/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsch/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jsch</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsh-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsh-dsl/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jsh-dsl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jslt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jslt/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jslt</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-json-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-json-validator/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-json-validator</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonata/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonata/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jsonata</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonpath/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonpath/pom.xml
@@ -80,33 +80,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jsonpath</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -131,9 +105,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-jta</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-oauth/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-oauth/pom.xml
@@ -120,33 +120,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-oauth</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -171,9 +145,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl-ssl/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-sasl-ssl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-sasl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-ssl/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-ssl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kamelet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kamelet/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kamelet</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-channel-consumer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-channel-consumer/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-knative-channel-consumer</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-endpoint-consumer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-endpoint-consumer/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-knative-endpoint-consumer</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-event-consumer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-event-consumer/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-knative-event-consumer</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-producer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-producer/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-knative-producer</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-knative</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin-dsl/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kotlin-dsl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin/pom.xml
@@ -97,33 +97,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kotlin</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -148,9 +122,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kubernetes/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kubernetes/pom.xml
@@ -105,33 +105,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kubernetes</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -156,9 +130,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kudu/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kudu/pom.xml
@@ -104,33 +104,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-kudu</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -155,9 +129,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ldap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ldap/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-ldap</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-leveldb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-leveldb/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-leveldb</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lra/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lra/pom.xml
@@ -112,33 +112,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-lra</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -163,9 +137,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lumberjack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lumberjack/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-lumberjack</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
@@ -106,33 +106,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-mail</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -157,9 +131,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-collector/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-collector/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-collector</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-devmode/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-devmode/pom.xml
@@ -117,33 +117,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-devmode</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -168,9 +142,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-discovery-disabled/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-discovery-disabled/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-discovery-disabled</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io-with-beans/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io-with-beans/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-xml-io-with-beans</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-xml-io</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-jaxb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-jaxb/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-xml-jaxb</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-yaml/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-yaml/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main-yaml</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main/pom.xml
@@ -97,33 +97,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-main</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -148,9 +122,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-management/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-management/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-management</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-microprofile</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-minio/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-minio/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-minio</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mllp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mllp/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-mllp</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mongodb-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mongodb-grouped/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-mongodb-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mustache/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mustache/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-mustache</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mybatis/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mybatis/pom.xml
@@ -95,33 +95,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-mybatis</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -146,9 +120,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nats/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nats/pom.xml
@@ -106,33 +106,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-nats</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -157,9 +131,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-netty/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-netty/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-netty</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nitrite/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nitrite/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-nitrite</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-oaipmh/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-oaipmh/pom.xml
@@ -133,33 +133,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-oaipmh</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -184,9 +158,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ognl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ognl/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-ognl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-olingo4/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-olingo4/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-olingo4</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openapi-java/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openapi-java/pom.xml
@@ -86,33 +86,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-openapi-java</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -137,9 +111,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openstack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openstack/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-openstack</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-opentelemetry/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-opentelemetry/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-opentelemetry</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-optaplanner/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-optaplanner/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-optaplanner</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
@@ -107,33 +107,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-paho-mqtt5</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -158,9 +132,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-paho</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pdf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pdf/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pdf</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pg-replication-slot/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pg-replication-slot/pom.xml
@@ -106,33 +106,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -157,9 +131,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pgevent/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pgevent/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pgevent</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy-ssl/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http-proxy-ssl</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http-proxy</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-protobuf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-protobuf/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-protobuf</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pubnub/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pubnub/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-pubnub</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-quartz/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-quartz/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-quartz</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qute/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qute/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-qute</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-reactive-streams/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-reactive-streams/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-reactive-streams</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest-openapi/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest-openapi/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-rest-openapi</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-rest</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saga/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saga/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-saga</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-salesforce/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-salesforce/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-salesforce</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sap-netweaver/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sap-netweaver/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-sap-netweaver</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saxon/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saxon/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-saxon</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servicenow/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servicenow/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-servicenow</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servlet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servlet/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-servlet</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-shiro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-shiro/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-shiro</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-artemis-client/pom.xml
@@ -99,33 +99,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms-artemis-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -150,9 +124,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-qpid-amqp-client/pom.xml
@@ -105,33 +105,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms-qpid-amqp-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -156,9 +130,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-artemis-client/pom.xml
@@ -99,33 +99,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms2-artemis-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -150,9 +124,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-qpid-amqp-client/pom.xml
@@ -105,33 +105,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms2-qpid-amqp-client</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -156,9 +130,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-slack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-slack/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-slack</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smallrye-reactive-messaging/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smallrye-reactive-messaging/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-smallrye-reactive-messaging</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-soap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-soap/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-soap</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
@@ -106,33 +106,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-spring-rabbitmq</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -157,9 +131,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sql/pom.xml
@@ -118,33 +118,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-sql</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -169,9 +143,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ssh/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ssh/pom.xml
@@ -101,33 +101,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-ssh</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -152,9 +126,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stax/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stax/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-stax</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stringtemplate/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stringtemplate/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-stringtemplate</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-swift/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-swift/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-swift</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syslog/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syslog/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-syslog</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tarfile/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tarfile/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-tarfile</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-telegram/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-telegram/pom.xml
@@ -108,33 +108,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-telegram</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -159,9 +133,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tika/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tika/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-tika</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twitter/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twitter/pom.xml
@@ -96,33 +96,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-twitter</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -147,9 +121,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-univocity-parsers/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-univocity-parsers/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-univocity-parsers</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-validator/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-validator</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-velocity/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-velocity/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-velocity</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx-websocket/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx-websocket/pom.xml
@@ -90,33 +90,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-vertx-websocket</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -141,9 +115,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-vertx</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-weather/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-weather/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-weather</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-grouped/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-xml-grouped</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xmlsecurity/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xmlsecurity/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-xmlsecurity</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xpath/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xpath/pom.xml
@@ -85,33 +85,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-xpath</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -136,9 +110,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-zendesk/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-zendesk/pom.xml
@@ -91,33 +91,7 @@
           <dependenciesToScan>
             <dependency>org.apache.camel.quarkus:camel-quarkus-integration-test-zendesk</dependency>
           </dependenciesToScan>
-          <systemPropertyVariables>
-            <quarkus.http.test-port>${test.http.port.jvm}</quarkus.http.test-port>
-            <quarkus.http.test-ssl-port>${test.https.port.jvm}</quarkus.http.test-ssl-port>
-            <quarkus.https.test-port>${test.https.port.jvm}</quarkus.https.test-port>
-          </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <portNames>
-                <portName>test.http.port.jvm</portName>
-                <portName>test.https.port.jvm</portName>
-                <portName>test.http.port.native</portName>
-                <portName>test.https.port.native</portName>
-              </portNames>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -142,9 +116,6 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                    <quarkus.http.test-port>${test.http.port.native}</quarkus.http.test-port>
-                    <quarkus.http.test-ssl-port>${test.https.port.native}</quarkus.http.test-ssl-port>
-                    <quarkus.https.test-port>${test.https.port.native}</quarkus.https.test-port>
                   </systemProperties>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -380,18 +380,6 @@
                                     </release>
                                     <defaultTestConfig>
                                         <skip>false</skip>
-                                        <jvmSystemProperties>
-                                            <quarkus.http.test-port>$${test.http.port.jvm}</quarkus.http.test-port>
-                                            <quarkus.http.test-ssl-port>$${test.https.port.jvm}</quarkus.http.test-ssl-port>
-                                            <!-- https://github.com/quarkusio/quarkus/issues/20228  -->
-                                            <quarkus.https.test-port>$${test.https.port.jvm}</quarkus.https.test-port>
-                                        </jvmSystemProperties>
-                                        <nativeSystemProperties>
-                                            <quarkus.http.test-port>$${test.http.port.native}</quarkus.http.test-port>
-                                            <quarkus.http.test-ssl-port>$${test.https.port.native}</quarkus.http.test-ssl-port>
-                                            <!-- https://github.com/quarkusio/quarkus/issues/20228  -->
-                                            <quarkus.https.test-port>$${test.https.port.native}</quarkus.https.test-port>
-                                        </nativeSystemProperties>
                                         <transformWith>${resourcesdir}/xslt/camel/test-pom.xsl</transformWith>
                                     </defaultTestConfig>
                                     <testCatalogArtifact>org.apache.camel.quarkus:camel-quarkus-test-list::xml:${camel-quarkus-test-list.version}</testCatalogArtifact>

--- a/src/main/resources/xslt/camel/test-pom.xsl
+++ b/src/main/resources/xslt/camel/test-pom.xsl
@@ -114,27 +114,6 @@
                     </executions>
                 </plugin>
             </xsl:if>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>reserve-network-port</id>
-                        <goals>
-                            <goal>reserve-network-port</goal>
-                        </goals>
-                        <phase>process-test-resources</phase>
-                        <configuration>
-                            <portNames>
-                                <portName>test.http.port.jvm</portName>
-                                <portName>test.https.port.jvm</portName>
-                                <portName>test.http.port.native</portName>
-                                <portName>test.https.port.native</portName>
-                            </portNames>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </xsl:copy>
     </xsl:template>
 

--- a/src/main/resources/xslt/camel/test-pom.xsl
+++ b/src/main/resources/xslt/camel/test-pom.xsl
@@ -13,22 +13,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="/pom:project/pom:properties">
-        <xsl:copy>
-            <xsl:apply-templates select="@* | node()" />
-            <xsl:if test="/pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-solr'">
-                <solr.trust-store>${project.basedir}/target/ssl/trust-store.jks</solr.trust-store>
-            </xsl:if>
-        </xsl:copy>
-    </xsl:template>
-
     <xsl:template match="/pom:project/pom:dependencies">
-        <!-- prepend properties before dependencies if necessary -->
-        <xsl:if test="(not(/pom:project/pom:properties)) and (/pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-solr')">
-            <properties>
-                <solr.trust-store>${project.basedir}/target/ssl/trust-store.jks</solr.trust-store>
-            </properties>
-        </xsl:if>
         <xsl:copy>
             <xsl:apply-templates select="@* | node()" />
             <xsl:if test="/pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-debezium'">
@@ -52,42 +37,6 @@
     <xsl:template match="/pom:project/pom:build/pom:plugins">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()" />
-            <xsl:if test="/pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-solr'">
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>exec-maven-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>extend-default-trust-store-extension</id>
-                            <phase>test-compile</phase>
-                            <goals>
-                                <goal>java</goal>
-                            </goals>
-                            <configuration>
-                                <mainClass>org.apache.camel.quarkus.test.ExtendDefaultTrustStore</mainClass>
-                                <arguments>
-                                    <argument>${solr.trust-store}</argument>
-                                    <argument>ssl/solr-ssl.der</argument>
-                                </arguments>
-                                <includePluginDependencies>true</includePluginDependencies>
-                            </configuration>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.camel.quarkus</groupId>
-                            <artifactId>camel-quarkus-integration-test-support</artifactId>
-                            <version>${camel-quarkus-test-list.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.apache.camel.quarkus</groupId>
-                            <artifactId>camel-quarkus-integration-test-solr</artifactId>
-                            <version>${camel-quarkus-test-list.version}</version>
-                            <classifier>tests</classifier>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </xsl:if>
             <xsl:if test="/pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-js-dsl'">
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -114,16 +63,6 @@
                     </executions>
                 </plugin>
             </xsl:if>
-        </xsl:copy>
-    </xsl:template>
-
-  <!-- Forward solr.trust-store to the tests via surefire plugin -->
-    <xsl:template match="//*[local-name() = 'systemPropertyVariables']">
-        <xsl:copy>
-            <xsl:if test="/pom:project/pom:artifactId/text() = 'camel-quarkus-integration-test-solr'">
-                <javax.net.ssl.trustStore>${solr.trust-store}</javax.net.ssl.trustStore>
-            </xsl:if>
-            <xsl:apply-templates select="@* | node()" />
         </xsl:copy>
     </xsl:template>
 


### PR DESCRIPTION
Some tidying of the Camel Quarkus itest poms.

* Removes port randomization as per https://github.com/apache/camel-quarkus/pull/5021
* Removes custom transforms for non-existent `camel-quarkus-integration-test-solr`

If it works ok, I'd like to do the same on 3.2 for consistency.