### PR TITLE
Update to Quarkus Qpid JMS 2.5.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -985,12 +985,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -7110,7 +7110,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
@@ -27,13 +27,13 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-server</artifactId>
-      <version>2.28.0</version>
+      <version>2.31.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-amqp-protocol</artifactId>
-      <version>2.28.0</version>
+      <version>2.31.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -14247,12 +14247,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -20792,7 +20792,7 @@
       <dependency>
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <quarkus-amazon-services.version>2.5.3</quarkus-amazon-services.version>
         <quarkus-cxf.version>2.6.1</quarkus-cxf.version>
         <quarkus-config-consul.version>2.2.2</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>2.4.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>2.3.3.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 2.5.0, uses Qpid JMS 2.5.0 against Quarkus 3.6.0