### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo -n ${{ github.event.number }} > pull-request-number
       - name: Upload pull request number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: pull-request-number-${{ github.event.number }}
           path: pull-request-number
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: rm -rf ~/.m2/repository/io/quarkus/quarkus-universe-bom*
       - name: Upload build reports (if build failed)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: ${{ failure() || cancelled() }}
         with:
           name: "build-reports-Build - JDK ${{ matrix.java }}"


### PR DESCRIPTION
v4 is unstable and generates URL that are not valid JDK-wise.