### PR TITLE
Upgrade to Debezium 2.5.0.Final

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -549,70 +549,70 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-api</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mongodb</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-postgres</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-sqlserver</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ddl-parser</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage-file</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage-kafka</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>

--- a/generated-platform-project/quarkus-debezium/bom/pom.xml
+++ b/generated-platform-project/quarkus-debezium/bom/pom.xml
@@ -61,82 +61,82 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-api</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-db2</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mongodb</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-oracle</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-postgres</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-sqlserver</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-vitess</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ddl-parser</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-deployment</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-deployment</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -5181,110 +5181,110 @@
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-api</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-db2</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mongodb</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-mysql</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-oracle</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-postgres</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-sqlserver</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-connector-vitess</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-core</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ddl-parser</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-embedded</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-deployment</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-deployment</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage-file</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage-kafka</artifactId>
-        <version>2.4.2.Final</version>
+        <version>2.5.0.Final</version>
       </dependency>
       <dependency>
         <groupId>io.dekorate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
-        <debezium-quarkus-outbox.version>2.4.2.Final</debezium-quarkus-outbox.version>
+        <debezium-quarkus-outbox.version>2.5.0.Final</debezium-quarkus-outbox.version>
         <quarkus-blaze-persistence.version>1.6.10</quarkus-blaze-persistence.version>
         <quarkus-cassandra-client.version>1.2.0</quarkus-cassandra-client.version>
         <quarkus-cassandra-client-test.version>${quarkus-cassandra-client.version}</quarkus-cassandra-client-test.version>


### PR DESCRIPTION
Upgrade Platform to Debezium 2.5.0.Final baseline

- [x] Address Hibernate ORM issue in Test Suite, per request from Guillaume

The above should be fixed with the Debezium upgrade to 2.4+, which uses OpenTelemetry over OpenTracing, @gsmet.