### PR TITLE
Vault 3.5.0

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -9378,17 +9378,17 @@
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-model</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.xmlsec</groupId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -4201,17 +4201,17 @@
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-model</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.24.2</version>
+      <version>3.25.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <optaplanner-quarkus.version>9.37.0.Final</optaplanner-quarkus.version>
 
         <quarkus-google-cloud-services.version>2.7.0</quarkus-google-cloud-services.version>
-        <quarkus-vault.version>3.4.0</quarkus-vault.version>
+        <quarkus-vault.version>3.5.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>6.6.3</quarkus-operator-sdk.version>
 
         <quarkus-platform-bom-generator.version>0.0.102</quarkus-platform-bom-generator.version>


### PR DESCRIPTION
https://github.com/quarkiverse/quarkus-vault/releases/tag/3.5.0 - Quarkus 3.8, JDK 17 + bug fix
note that the synch operation modified also assertj version to `3.25.3` (like in vault), which I did not include in this PR