### PR TITLE
[3.8] Update to Quarkus Qpid JMS 2.6.0

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -954,12 +954,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -14621,12 +14621,12 @@
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms-deployment</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.amqphub.quarkus</groupId>
         <artifactId>quarkus-qpid-jms</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <quarkus-amazon-services.version>2.12.1</quarkus-amazon-services.version>
         <quarkus-cxf.version>3.8.0</quarkus-cxf.version>
         <quarkus-config-consul.version>2.2.2</quarkus-config-consul.version>
-        <quarkus-qpid-jms.version>2.5.0</quarkus-qpid-jms.version>
+        <quarkus-qpid-jms.version>2.6.0</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>3.0.0</quarkus-hazelcast-client.version>
         <debezium-quarkus-outbox.version>2.5.0.Final</debezium-quarkus-outbox.version>


### PR DESCRIPTION
Update to Quarkus Qpid JMS 2.6.0, uses Qpid JMS 2.5.0 against Quarkus 3.8.1