### PR TITLE
Upgrade platform generator to 0.0.106

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <quarkus-vault.version>4.0.1</quarkus-vault.version>
         <quarkus-operator-sdk.version>6.6.8</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.103</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.106</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>


### PR DESCRIPTION
This version enables the initial version of parallel platform generation tasks processing.
With an empty local Maven repository it saves ~30% for `-Dsync` (~7 min vs ~10 min) and ~50% (~4.5 sec vs 9.5 sec) on subsequent runs.

To run the generation tasks sequentially `-DsequentialTaskScheduler` can be added to the command line.