### PR TITLE
Vault 4.1.0

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -9703,12 +9703,12 @@
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -4261,12 +4261,12 @@
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault-deployment</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>
         <artifactId>quarkus-vault</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus.arc</groupId>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.25.3</version>
+      <version>3.26.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <optaplanner-quarkus.version>9.37.0.Final</optaplanner-quarkus.version>
 
         <quarkus-google-cloud-services.version>2.9.0</quarkus-google-cloud-services.version>
-        <quarkus-vault.version>4.0.1</quarkus-vault.version>
+        <quarkus-vault.version>4.1.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>6.7.1</quarkus-operator-sdk.version>
 
         <quarkus-platform-bom-generator.version>0.0.106</quarkus-platform-bom-generator.version>


### PR DESCRIPTION
required for quarkus `3.12` because of:
* Use quarkus.tls.trust-all property directly by @geoand in https://github.com/quarkiverse/quarkus-vault/pull/285
* Use defaultValue = false for quarkus.tls.trust-all by @geoand in https://github.com/quarkiverse/quarkus-vault/pull/288

cc @gsmet 
