### PR TITLE
Update Quarkus Amazon Services to 2.18.1

### DIFF
--- a/generated-platform-project/quarkus-amazon-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/bom/pom.xml
@@ -61,382 +61,382 @@
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-apache-client-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-apache-client-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatch-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatch</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatchlogs-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatchlogs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cognito-user-pools-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cognito-user-pools</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common-deployment-devservices-spi</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common-deployment-spi</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt-client-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt-client-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-cloudwatch</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-cloudwatchlogs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-cognito-user-pools</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-dynamodb</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-ecr</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-eventbridge</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-iam</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-kinesis</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-kms</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-lambda</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-s3</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-secretsmanager</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-ses</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sfn</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sns</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sqs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-ssm</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sts</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb-enhanced-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb-enhanced</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ecr-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ecr</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-eventbridge-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-eventbridge</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-iam-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-iam</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector2-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector2</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kinesis-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kinesis</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kms-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kms</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-lambda-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-lambda</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-netty-client-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-netty-client-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-opentelemetry-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-opentelemetry-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3-transfer-manager-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3-transfer-manager</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-secretsmanager-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-secretsmanager</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ses-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ses</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sfn-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sfn</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sns-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sns</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sqs-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sqs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ssm-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ssm</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sts-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sts</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk.crt</groupId>

--- a/generated-platform-project/quarkus-amazon-services/integration-tests/quarkus-amazon-services-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/integration-tests/quarkus-amazon-services-integration-tests/pom.xml
@@ -24,6 +24,49 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-osgi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -9226,382 +9226,382 @@
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-apache-client-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-apache-client-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatch-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatch</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatchlogs-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cloudwatchlogs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cognito-user-pools-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-cognito-user-pools</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common-deployment-devservices-spi</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common-deployment-spi</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-common</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt-client-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt-client-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-crt</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-cloudwatch</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-cloudwatchlogs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-cognito-user-pools</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-dynamodb</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-ecr</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-eventbridge</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-iam</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-kinesis</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-kms</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-lambda</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-s3</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-secretsmanager</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-ses</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sfn</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sns</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sqs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-ssm</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-devservices-sts</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb-enhanced-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb-enhanced</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-dynamodb</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ecr-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ecr</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-eventbridge-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-eventbridge</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-iam-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-iam</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector2-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector2</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-inspector</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kinesis-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kinesis</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kms-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-kms</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-lambda-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-lambda</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-netty-client-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-netty-client-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-opentelemetry-internal-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-opentelemetry-internal</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3-transfer-manager-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3-transfer-manager</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-s3</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-secretsmanager-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-secretsmanager</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ses-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ses</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sfn-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sfn</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sns-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sns</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sqs-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sqs</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ssm-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-ssm</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sts-deployment</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.amazonservices</groupId>
         <artifactId>quarkus-amazon-sts</artifactId>
-        <version>2.18.0</version>
+        <version>2.18.1</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.config</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
              make sure you have a look at the AmazonServices member section below
              and also at src/main/resources/xslt/amazon-services/test-pom.xsl
              as they might require adjustments. -->
-        <quarkus-amazon-services.version>2.18.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
         <quarkus-cxf.version>3.14.0</quarkus-cxf.version>
         <quarkus-config-consul.version>2.2.2</quarkus-config-consul.version>
         <quarkus-qpid-jms.version>2.7.0</quarkus-qpid-jms.version>


### PR DESCRIPTION
The previous PR mistakenly committed version 2.18.0.


Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
