### PR TITLE
Upgrade the platform generator version to 0.0.113

### DIFF
--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -73,7 +73,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-amazon-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/bom/pom.xml
@@ -2608,7 +2608,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-amazon-services/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-amazon-services-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-amazon-services/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-amazon-services/integration-tests/quarkus-amazon-services-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/integration-tests/quarkus-amazon-services-integration-tests/pom.xml
@@ -136,7 +136,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
@@ -108,7 +108,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-blaze-persistence-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-blaze-persistence/integration-tests/blaze-persistence-examples-quarkus-3-testsuite-native-h2/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/integration-tests/blaze-persistence-examples-quarkus-3-testsuite-native-h2/pom.xml
@@ -92,7 +92,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-blaze-persistence/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/integration-tests/pom.xml
@@ -31,12 +31,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -8615,7 +8615,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-camel/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-camel/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-camel-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-activemq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-activemq/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -73,14 +73,14 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-jms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -161,7 +161,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-activemq:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-activemq:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-amqp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-amqp/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-amqp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-amqp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,20 +57,20 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-jms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -151,7 +151,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-amqp:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-amqp:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-arangodb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-arangodb/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-arangodb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-arangodb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-arangodb:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-arangodb:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-as2/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-as2/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-as2</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-as2</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-as2:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-as2:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-avro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-avro/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-avro</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-avro</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-avro:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-avro:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-aws2-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-aws2-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -178,7 +178,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -186,7 +186,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-quarkus-client-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-quarkus-client-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-aws2-quarkus-client-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-aws2-quarkus-client-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-aws2</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -167,7 +167,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -175,7 +175,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2-quarkus-client-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2-quarkus-client-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-aws2</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-aws2</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -96,7 +96,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -104,7 +104,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-aws2:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-azure-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-azure-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-azure</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-azure-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-azure-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-base64/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-base64/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-base64</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-base64</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-base64:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-base64:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bean-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bean-validator/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-bean-validator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-bean-validator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-bean-validator:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-bean-validator:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bindy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bindy/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-bindy</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-bindy</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -118,7 +118,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -126,7 +126,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-bindy:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-bindy:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-box/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-box/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-box</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-box</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-box:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-box:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-braintree/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-braintree/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-braintree</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-braintree</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-braintree:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-braintree:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-caffeine/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-caffeine/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-caffeine</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-caffeine</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-caffeine:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-caffeine:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cassandraql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cassandraql/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-cassandraql</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-cassandraql</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -175,7 +175,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -183,7 +183,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cassandraql:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cassandraql:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cbor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cbor/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-cbor</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-cbor</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cbor:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cbor:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-compression-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-compression-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-compression-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-compression-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-compression-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-compression-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-consul/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-consul/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-consul</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-consul</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-consul:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-consul:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-core-discovery-disabled/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-core-discovery-disabled/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-core-discovery-disabled</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-core-discovery-disabled</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-core-discovery-disabled:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-core-discovery-disabled:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-couchdb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-couchdb/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-couchdb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-couchdb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -152,7 +152,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-couchdb:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-couchdb:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto-pgp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto-pgp/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-crypto-pgp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-crypto-pgp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-crypto-pgp:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-crypto-pgp:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-crypto</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-crypto</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-crypto:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-crypto:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csimple/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csimple/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-csimple</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-csimple</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-csimple:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-csimple:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csv/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csv/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-csv</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-csv</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-csv:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-csv:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-cxf-soap-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-cxf-soap-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -162,7 +162,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -170,7 +170,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cxf-soap-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-cxf-soap-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformat/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformat/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-dataformat</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-dataformat</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-dataformat:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-dataformat:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformats-json-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformats-json-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-dataformats-json-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-dataformats-json-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-dataformats-json-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-dataformats-json-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-datasonnet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-datasonnet/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-datasonnet</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-datasonnet</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-datasonnet:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-datasonnet:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
@@ -15,12 +15,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-debezium</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-debezium</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -193,7 +193,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -202,7 +202,7 @@
                 </goals>
                 <configuration>
                   <skip>true</skip>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-debezium:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-debezium:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debug/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debug/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-debug</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-debug</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-debug:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-debug:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-digitalocean/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-digitalocean/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-digitalocean</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-digitalocean</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-digitalocean:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-digitalocean:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-disruptor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-disruptor/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-disruptor</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-disruptor</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-disruptor:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-disruptor:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dropbox/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dropbox/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-dropbox</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-dropbox</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-dropbox:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-dropbox:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-elasticsearch-rest-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-elasticsearch-rest-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-elasticsearch-rest-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-elasticsearch-rest-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -158,7 +158,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-elasticsearch-rest-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-elasticsearch-rest-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-exec/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-exec/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-exec</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-exec</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-exec:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-exec:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fhir/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fhir/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-fhir</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-fhir</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -145,7 +145,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -153,7 +153,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-fhir:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-fhir:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-file/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-file/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-file</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-file</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-file:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-file:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-flatpack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-flatpack/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-flatpack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-flatpack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-flatpack:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-flatpack:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fop/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fop/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-fop</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-fop</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-fop:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-fop:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-foundation-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-foundation-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-foundation-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-foundation-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -159,7 +159,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-foundation-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-foundation-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-freemarker/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-freemarker/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-freemarker</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-freemarker</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-freemarker:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-freemarker:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ftp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ftp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -171,7 +171,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -179,7 +179,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ftp:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ftp:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-geocoder/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-geocoder/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-geocoder</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-geocoder</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-geocoder:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-geocoder:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-git/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-git/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-git</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-git</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-git:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-git:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-github/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-github/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-github</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-github</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-github:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-github:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-bigquery/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-bigquery/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google-bigquery</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google-bigquery</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-google</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-bigquery:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-bigquery:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google-pubsub</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google-pubsub</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-google</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-pubsub:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-pubsub:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-storage/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-storage/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google-storage</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google-storage</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-storage:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google-storage:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-google</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-google:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-graphql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-graphql/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-graphql</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-graphql</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-graphql:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-graphql:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grok/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grok/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-grok</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-grok</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-grok:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-grok:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy-dsl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-groovy-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-groovy-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -102,7 +102,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -110,7 +110,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-groovy-dsl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-groovy-dsl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-groovy</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-groovy</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -107,7 +107,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -115,7 +115,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-groovy:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-groovy:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grpc/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grpc/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-grpc</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-grpc</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -148,7 +148,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-grpc:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-grpc:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hazelcast/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hazelcast/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-hazelcast</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-hazelcast</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-hazelcast:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-hazelcast:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-headersmap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-headersmap/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-headersmap</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-headersmap</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-headersmap:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-headersmap:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hl7/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hl7/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-hl7</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-hl7</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-hl7:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-hl7:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-http-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-http-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -73,13 +73,13 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -159,7 +159,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-http-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-http-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-common/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-common/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan-common:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan-common:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-quarkus-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-quarkus-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan-quarkus-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan-quarkus-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan-quarkus-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan-quarkus-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-infinispan-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -146,7 +146,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -154,7 +154,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-infinispan:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-influxdb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-influxdb/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-influxdb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-influxdb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-influxdb:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-influxdb:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-avro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-avro/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jackson-avro</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jackson-avro</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jackson-avro:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jackson-avro:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-protobuf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-protobuf/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jackson-protobuf</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jackson-protobuf</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jackson-protobuf:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jackson-protobuf:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jasypt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jasypt/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jasypt</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jasypt</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jasypt:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jasypt:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-java-joor-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-java-joor-dsl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-java-joor-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-java-joor-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-java-joor-dsl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-java-joor-dsl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jaxb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jaxb/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jaxb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jaxb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jaxb:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jaxb:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jcache/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jcache/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jcache</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jcache</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jcache:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jcache:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jdbc-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jdbc-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jdbc-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jdbc-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-jdbc</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -141,7 +141,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -149,7 +149,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jdbc-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jdbc-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jfr/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jfr/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jfr</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jfr</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jfr:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jfr:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jira/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jira/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jira</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jira</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -148,7 +148,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jira:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jira:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jms-artemis-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jms-artemis-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,20 +57,20 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-jms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -151,7 +151,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-artemis-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-artemis-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-ibmmq-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-ibmmq-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jms-ibmmq-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jms-ibmmq-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -73,14 +73,14 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-jms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -161,7 +161,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-ibmmq-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-ibmmq-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jms-qpid-amqp-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jms-qpid-amqp-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,20 +57,20 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-jms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -151,7 +151,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-qpid-amqp-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jms-qpid-amqp-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jolt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jolt/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jolt</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jolt</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jolt:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jolt:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-joor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-joor/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-joor</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-joor</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-joor:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-joor:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jpa/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jpa/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jpa</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jpa</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jpa:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jpa:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jq/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jq:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jq:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-js-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-js-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -161,7 +161,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-js-dsl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsch/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsch/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsch</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsch</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsch:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsch:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsh-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsh-dsl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsh-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsh-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsh-dsl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsh-dsl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jslt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jslt/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jslt</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jslt</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jslt:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jslt:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-json-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-json-validator/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-json-validator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-json-validator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-json-validator:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-json-validator:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonata/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonata/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsonata</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsonata</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsonata:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsonata:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonpath/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonpath/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsonpath</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jsonpath</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -118,7 +118,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -126,7 +126,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsonpath:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jsonpath:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400-mocked/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400-mocked/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jt400-mocked</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jt400-mocked</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -127,7 +127,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -135,7 +135,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jt400-mocked:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jt400-mocked:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jt400</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jt400</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jt400:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jt400:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jta</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-jta</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jta:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-jta:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-oauth/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-oauth/pom.xml
@@ -15,12 +15,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-oauth</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-oauth</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -163,7 +163,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -172,7 +172,7 @@
                 </goals>
                 <configuration>
                   <skip>true</skip>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-oauth:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-oauth:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl-ssl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-sasl-ssl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-sasl-ssl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -148,7 +148,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-sasl-ssl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-sasl-ssl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-sasl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-sasl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-sasl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-sasl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-ssl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-ssl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka-ssl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -148,7 +148,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-ssl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka-ssl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kafka</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kafka:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kamelet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kamelet/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kamelet</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kamelet</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kamelet:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kamelet:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-knative</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-knative</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-knative:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-knative:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin-dsl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kotlin-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kotlin-dsl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kotlin-dsl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kotlin-dsl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kotlin</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kotlin</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kotlin:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kotlin:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kubernetes/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kubernetes/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kubernetes</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kubernetes</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -151,7 +151,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kubernetes:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kubernetes:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kudu/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kudu/pom.xml
@@ -15,12 +15,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kudu</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-kudu</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -142,7 +142,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -151,7 +151,7 @@
                 </goals>
                 <configuration>
                   <skip>true</skip>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kudu:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-kudu:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-langchain4j-chat/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-langchain4j-chat/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-langchain4j-chat</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-langchain4j-chat</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-langchain4j-chat:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-langchain4j-chat:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ldap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ldap/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ldap</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ldap</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ldap:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ldap:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-leveldb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-leveldb/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-leveldb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-leveldb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-leveldb:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-leveldb:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lra/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lra/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-lra</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-lra</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -158,7 +158,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-lra:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-lra:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lumberjack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lumberjack/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-lumberjack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-lumberjack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -148,7 +148,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-lumberjack:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-lumberjack:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mail</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mail</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -158,7 +158,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mail:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mail:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-collector/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-collector/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-collector</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-collector</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-collector:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-collector:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-devmode/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-devmode/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-devmode</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-devmode</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -155,7 +155,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -163,7 +163,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-devmode:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-devmode:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-discovery-disabled/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-discovery-disabled/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-discovery-disabled</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-discovery-disabled</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-discovery-disabled:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-discovery-disabled:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-xml-io</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-xml-io</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-xml-io:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-xml-io:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-jaxb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-jaxb/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-xml-jaxb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-xml-jaxb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-xml-jaxb:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-xml-jaxb:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-yaml/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-yaml/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-yaml</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main-yaml</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-yaml:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main-yaml:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-main</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-main:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-management/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-management/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-management</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-management</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-management:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-management:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mapstruct/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mapstruct/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mapstruct</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mapstruct</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mapstruct:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mapstruct:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-micrometer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-micrometer/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-micrometer</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-micrometer</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-micrometer:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-micrometer:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile-fault-tolerance/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile-fault-tolerance/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-microprofile-fault-tolerance</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-microprofile-fault-tolerance</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-microprofile-fault-tolerance:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-microprofile-fault-tolerance:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile-health/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile-health/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-microprofile-health</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-microprofile-health</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-microprofile-health:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-microprofile-health:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-minio/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-minio/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-minio</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-minio</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-minio:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-minio:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mllp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mllp/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mllp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mllp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mllp:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mllp:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mongodb-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mongodb-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mongodb-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mongodb-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mongodb-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mongodb-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mustache/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mustache/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mustache</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mustache</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mustache:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mustache:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mybatis/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mybatis/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mybatis</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-mybatis</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -133,7 +133,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -141,7 +141,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mybatis:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-mybatis:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nats/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nats/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-nats</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-nats</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -158,7 +158,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-nats:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-nats:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-netty/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-netty/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-netty</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-netty</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-netty:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-netty:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nitrite/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nitrite/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-nitrite</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-nitrite</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-nitrite:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-nitrite:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-oaipmh/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-oaipmh/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-oaipmh</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-oaipmh</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -172,7 +172,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -180,7 +180,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-oaipmh:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-oaipmh:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ognl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ognl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ognl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ognl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ognl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ognl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-olingo4/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-olingo4/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-olingo4</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-olingo4</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-olingo4:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-olingo4:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openapi-java/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openapi-java/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-openapi-java</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-openapi-java</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -124,7 +124,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -132,7 +132,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-openapi-java:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-openapi-java:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openstack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openstack/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-openstack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-openstack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-openstack:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-openstack:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-opentelemetry/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-opentelemetry/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-opentelemetry</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-opentelemetry</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-opentelemetry:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-opentelemetry:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-optaplanner/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-optaplanner/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-optaplanner</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-optaplanner</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-optaplanner:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-optaplanner:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-paho-mqtt5</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-paho-mqtt5</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -73,13 +73,13 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -159,7 +159,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-paho-mqtt5:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-paho-mqtt5:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-paho</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-paho</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-paho:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-paho:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pdf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pdf/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pdf</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pdf</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pdf:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pdf:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pg-replication-slot/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pg-replication-slot/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pg-replication-slot</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pg-replication-slot</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -152,7 +152,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pg-replication-slot:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pgevent/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pgevent/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pgevent</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pgevent</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pgevent:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pgevent:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pinecone/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pinecone/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pinecone</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pinecone</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pinecone:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pinecone:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy-ssl/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-platform-http-proxy-ssl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-platform-http-proxy-ssl</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http-proxy-ssl:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http-proxy-ssl:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-platform-http-proxy</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-platform-http-proxy</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http-proxy:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http-proxy:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-platform-http</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-platform-http</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-platform-http:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-protobuf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-protobuf/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-protobuf</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-protobuf</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-protobuf:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-protobuf:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pubnub/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pubnub/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pubnub</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-pubnub</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pubnub:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-pubnub:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qdrant/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qdrant/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-qdrant</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-qdrant</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-qdrant:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-qdrant:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-quartz/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-quartz/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-quartz</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-quartz</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-quartz:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-quartz:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qute/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qute/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-qute</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-qute</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-qute:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-qute:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-reactive-streams/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-reactive-streams/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-reactive-streams</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-reactive-streams</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-reactive-streams:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-reactive-streams:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest-openapi/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest-openapi/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-rest-openapi</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-rest-openapi</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-rest-openapi:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-rest-openapi:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-rest</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-rest</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-rest:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-rest:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saga/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saga/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-saga</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-saga</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-saga:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-saga:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-salesforce/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-salesforce/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-salesforce</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-salesforce</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-salesforce:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-salesforce:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sap-netweaver/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sap-netweaver/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sap-netweaver</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sap-netweaver</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sap-netweaver:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sap-netweaver:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saxon/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saxon/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-saxon</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-saxon</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-saxon:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-saxon:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servicenow/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servicenow/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-servicenow</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-servicenow</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-servicenow:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-servicenow:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servlet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servlet/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-servlet</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-servlet</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-servlet:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-servlet:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-shiro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-shiro/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-shiro</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-shiro</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-shiro:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-shiro:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-artemis-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms-artemis-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms-artemis-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,14 +57,14 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-sjms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -145,7 +145,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms-artemis-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms-artemis-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-qpid-amqp-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms-qpid-amqp-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms-qpid-amqp-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,20 +57,20 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-sjms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -151,7 +151,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms-qpid-amqp-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms-qpid-amqp-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-artemis-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms2-artemis-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms2-artemis-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,14 +57,14 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-sjms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -145,7 +145,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms2-artemis-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms2-artemis-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-qpid-amqp-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms2-qpid-amqp-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sjms2-qpid-amqp-client</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,20 +57,20 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-activemq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-common</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-messaging-sjms</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -151,7 +151,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms2-qpid-amqp-client:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sjms2-qpid-amqp-client:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-slack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-slack/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-slack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-slack</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-slack:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-slack:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smallrye-reactive-messaging/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smallrye-reactive-messaging/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-smallrye-reactive-messaging</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-smallrye-reactive-messaging</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -136,7 +136,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-smallrye-reactive-messaging:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-smallrye-reactive-messaging:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smb/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-smb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-smb</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-smb:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-smb:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-soap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-soap/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-soap</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-soap</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-soap:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-soap:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk-hec/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk-hec/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-splunk-hec</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-splunk-hec</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-splunk</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk-hec:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk-hec:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-splunk</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-splunk</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-splunk</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -130,7 +130,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -138,7 +138,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-splunk:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-spring-rabbitmq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-spring-rabbitmq</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -158,7 +158,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-spring-rabbitmq:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-spring-rabbitmq:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sql/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sql</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-sql</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -158,7 +158,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sql:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-sql:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ssh/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ssh/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ssh</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-ssh</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -147,7 +147,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ssh:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-ssh:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stax/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stax/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-stax</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-stax</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-stax:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-stax:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stringtemplate/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stringtemplate/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-stringtemplate</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-stringtemplate</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-stringtemplate:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-stringtemplate:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-swift/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-swift/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-swift</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-swift</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-swift:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-swift:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syndication/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syndication/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-syndication</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-syndication</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-syndication:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-syndication:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syslog/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syslog/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-syslog</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-syslog</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-syslog:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-syslog:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tarfile/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tarfile/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-tarfile</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-tarfile</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-tarfile:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-tarfile:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-telegram/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-telegram/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-telegram</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-telegram</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -25,13 +25,13 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -146,7 +146,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -154,7 +154,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-telegram:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-telegram:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tika/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tika/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-tika</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-tika</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-tika:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-tika:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twilio/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twilio/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-twilio</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-twilio</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-twilio:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-twilio:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twitter/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twitter/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-twitter</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-twitter</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-twitter:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-twitter:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-univocity-parsers/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-univocity-parsers/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-univocity-parsers</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-univocity-parsers</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-univocity-parsers:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-univocity-parsers:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-validator/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-validator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-validator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-validator:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-validator:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-velocity/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-velocity/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-velocity</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-velocity</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-velocity:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-velocity:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx-websocket/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx-websocket/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-vertx-websocket</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-vertx-websocket</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-tests-support-certificate-generator</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-vertx-websocket:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-vertx-websocket:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-vertx</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-vertx</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-vertx:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-vertx:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-wasm/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-wasm/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-wasm</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-wasm</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-wasm:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-wasm:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-weather/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-weather/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-weather</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-weather</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-weather:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-weather:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xchange/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xchange/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xchange</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xchange</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xchange:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xchange:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xj/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xj/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xj</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xj</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xj:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xj:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-grouped/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xml-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xml-grouped</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xml-grouped:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xml-grouped:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-jaxp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-jaxp/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xml-jaxp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xml-jaxp</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xml-jaxp:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xml-jaxp:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xmlsecurity/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xmlsecurity/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xmlsecurity</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xmlsecurity</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xmlsecurity:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xmlsecurity:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xpath/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xpath/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xpath</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xpath</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xpath:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xpath:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xslt-saxon/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xslt-saxon/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xslt-saxon</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-xslt-saxon</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -131,7 +131,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xslt-saxon:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-xslt-saxon:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-zendesk/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-zendesk/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-zendesk</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-test-zendesk</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-integration-wiremock-support</artifactId>
-      <version>3.15.0</version>
+      <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-zendesk:3.15.0</appArtifact>
+                  <appArtifact>org.apache.camel.quarkus:camel-quarkus-integration-test-zendesk:${camel-quarkus.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -224,12 +224,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-cassandra/bom/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/bom/pom.xml
@@ -209,7 +209,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-cassandra-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-dse/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-dse/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-main/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-main/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-disabled/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-disabled/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-microprofile/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-microprofile/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-no-mapper/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-no-mapper/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/pom.xml
@@ -34,12 +34,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-cxf/bom/pom.xml
+++ b/generated-platform-project/quarkus-cxf/bom/pom.xml
@@ -602,7 +602,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-cxf/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-cxf/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-cxf-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-cxf/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/pom.xml
@@ -44,12 +44,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client-server/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client-server/pom.xml
@@ -145,7 +145,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client/pom.xml
@@ -156,7 +156,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-fast-infoset/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-fast-infoset/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-hc5/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-hc5/pom.xml
@@ -145,7 +145,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-metrics/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-metrics/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtls/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtls/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom-awt/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom-awt/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-opentelemetry/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-opentelemetry/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-santuario-xmlsec/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-santuario-xmlsec/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-server/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-server/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-rm-client/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-rm-client/pom.xml
@@ -192,7 +192,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security-policy/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security-policy/pom.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security/pom.xml
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-trust/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-trust/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-debezium/bom/pom.xml
+++ b/generated-platform-project/quarkus-debezium/bom/pom.xml
@@ -168,7 +168,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-debezium/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-debezium/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-debezium-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-integration-tests/pom.xml
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-reactive-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-reactive-integration-tests/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-debezium/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-debezium/integration-tests/pom.xml
@@ -31,12 +31,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
@@ -4660,7 +4660,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-google-cloud-services-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-google-cloud-services/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-google-cloud-services/integration-tests/quarkus-google-cloud-services-main-it/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/integration-tests/quarkus-google-cloud-services-main-it/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-maven-plugin/pom.xml
+++ b/generated-platform-project/quarkus-maven-plugin/pom.xml
@@ -13,16 +13,12 @@
   <packaging>maven-plugin</packaging>
   <name>Quarkus Platform - Quarkus Maven Plugin</name>
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.testSource>11</maven.compiler.testSource>
     <maven.compiler.argument.target>11</maven.compiler.argument.target>
-    <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.argument.testSource>11</maven.compiler.argument.testSource>
     <maven.compiler.argument.testTarget>11</maven.compiler.argument.testTarget>
-    <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.testTarget>11</maven.compiler.testTarget>
     <maven.compiler.argument.source>11</maven.compiler.argument.source>
-    <maven.compiler.parameters>true</maven.compiler.parameters>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/generated-platform-project/quarkus-operator-sdk/bom/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/bom/pom.xml
@@ -133,7 +133,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-operator-sdk/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-operator-sdk-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-operator-sdk/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-operator-sdk/integration-tests/quarkus-operator-sdk-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/integration-tests/quarkus-operator-sdk-integration-tests/pom.xml
@@ -142,7 +142,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -103,7 +103,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-qpid-jms-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
@@ -154,7 +154,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -27980,7 +27980,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus-universe/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-universe/descriptor/pom.xml
@@ -52,7 +52,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-universe-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${project.groupId}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -12887,7 +12887,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>

--- a/generated-platform-project/quarkus/descriptor/pom.xml
+++ b/generated-platform-project/quarkus/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-bom</bomArtifactId>
-          <quarkusCoreVersion>3.15.0</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/pom.xml
@@ -33,12 +33,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.15.0</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-config-extensions-integration-test-consul/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-config-extensions-integration-test-consul/pom.xml
@@ -125,7 +125,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-agroal/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-agroal/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-app/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-app/pom.xml
@@ -138,7 +138,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
@@ -146,7 +146,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.15.0</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <quarkus-vault.version>4.1.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>6.8.0</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.112</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.113</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>


### PR DESCRIPTION
More appropriate version property mapping for Quarkus core and other member dependencies.
For POM files w/o parent POMs specific versions are preferred over properties, since these POMs typically don't define properties.