### PR TITLE
[3.8] Upgrade to Quarkus CXF 3.8.7

### DIFF
--- a/generated-platform-project/quarkus-amazon-services/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-amazon-services-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-amazon-services/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-amazon-services/integration-tests/quarkus-amazon-services-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/integration-tests/quarkus-amazon-services-integration-tests/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-blaze-persistence-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-blaze-persistence/integration-tests/blaze-persistence-examples-quarkus-3-testsuite-native-h2/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/integration-tests/blaze-persistence-examples-quarkus-3-testsuite-native-h2/pom.xml
@@ -92,7 +92,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-blaze-persistence/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/integration-tests/pom.xml
@@ -31,12 +31,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -682,27 +682,27 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-axiom-api-stub</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-bc-stub</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -713,107 +713,107 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.freemarker</groupId>
@@ -7181,17 +7181,17 @@
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.jackrabbit</groupId>

--- a/generated-platform-project/quarkus-camel/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-camel/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-camel-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-activemq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-activemq/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-amqp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-amqp/pom.xml
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-arangodb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-arangodb/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-avro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-avro/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-grouped/pom.xml
@@ -174,7 +174,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-quarkus-client-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2-quarkus-client-grouped/pom.xml
@@ -163,7 +163,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-aws2/pom.xml
@@ -96,7 +96,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-azure-grouped/pom.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-base64/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-base64/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bean-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bean-validator/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bindy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-bindy/pom.xml
@@ -118,7 +118,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-box/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-box/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-braintree/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-braintree/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-caffeine/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-caffeine/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-camel-k-runtime-model-reifier/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-camel-k-runtime-model-reifier/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-camel-k-runtime/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-camel-k-runtime/pom.xml
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cassandraql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cassandraql/pom.xml
@@ -167,7 +167,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cbor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cbor/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-compression-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-compression-grouped/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-consul/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-consul/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-core-discovery-disabled/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-core-discovery-disabled/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-couchdb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-couchdb/pom.xml
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-crypto/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csimple/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csimple/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csv/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-csv/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
@@ -168,7 +168,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformat/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformat/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformats-json-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dataformats-json-grouped/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-datasonnet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-datasonnet/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
@@ -193,7 +193,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debug/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debug/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-digitalocean/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-digitalocean/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-disruptor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-disruptor/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dropbox/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-dropbox/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-exec/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-exec/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fhir/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fhir/pom.xml
@@ -145,7 +145,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-file/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-file/pom.xml
@@ -126,7 +126,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-flatpack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-flatpack/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fop/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-fop/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-foundation-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-foundation-grouped/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-freemarker/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-freemarker/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ftp/pom.xml
@@ -171,7 +171,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-geocoder/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-geocoder/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-git/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-git/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-github/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-github/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-bigquery/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-bigquery/pom.xml
@@ -138,7 +138,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-pubsub/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-storage/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google-storage/pom.xml
@@ -145,7 +145,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-google/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-graphql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-graphql/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grok/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grok/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy-dsl/pom.xml
@@ -102,7 +102,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-groovy/pom.xml
@@ -107,7 +107,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grpc/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-grpc/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hazelcast/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hazelcast/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-headersmap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-headersmap/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hl7/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-hl7/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-http-grouped/pom.xml
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-common/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-common/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-quarkus-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan-quarkus-client/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-infinispan/pom.xml
@@ -146,7 +146,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-influxdb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-influxdb/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-avro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-avro/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-protobuf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jackson-protobuf/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jasypt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jasypt/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-java-joor-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-java-joor-dsl/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jaxb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jaxb/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jcache/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jcache/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jdbc-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jdbc-grouped/pom.xml
@@ -141,7 +141,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jfr/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jfr/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jira/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jira/pom.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-artemis-client/pom.xml
@@ -149,7 +149,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-ibmmq-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-ibmmq-client/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jms-qpid-amqp-client/pom.xml
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jolt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jolt/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-joor/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-joor/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jpa/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jpa/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jq/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-js-dsl/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsch/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsch/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsh-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsh-dsl/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jslt/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jslt/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-json-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-json-validator/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonata/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonata/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonpath/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jsonpath/pom.xml
@@ -118,7 +118,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400-mocked/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400-mocked/pom.xml
@@ -127,7 +127,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jt400/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-jta/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-oauth/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-oauth/pom.xml
@@ -163,7 +163,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl-ssl/pom.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-sasl/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka-ssl/pom.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kafka/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kamelet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kamelet/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-channel-consumer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-channel-consumer/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-endpoint-consumer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-endpoint-consumer/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-event-consumer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-event-consumer/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-producer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative-producer/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-knative/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin-dsl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin-dsl/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kotlin/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kubernetes/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kubernetes/pom.xml
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kudu/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-kudu/pom.xml
@@ -142,7 +142,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ldap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ldap/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-leveldb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-leveldb/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lra/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lra/pom.xml
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lumberjack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-lumberjack/pom.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mail/pom.xml
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-collector/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-collector/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-devmode/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-devmode/pom.xml
@@ -155,7 +155,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-discovery-disabled/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-discovery-disabled/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io-with-beans/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io-with-beans/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-io/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-jaxb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-xml-jaxb/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-yaml/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main-yaml/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-main/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-management/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-management/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mapstruct/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mapstruct/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-micrometer/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-micrometer/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-microprofile/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-minio/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-minio/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mllp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mllp/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mongodb-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mongodb-grouped/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mustache/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mustache/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mybatis/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-mybatis/pom.xml
@@ -133,7 +133,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nats/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nats/pom.xml
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-netty/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-netty/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nitrite/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-nitrite/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-oaipmh/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-oaipmh/pom.xml
@@ -172,7 +172,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ognl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ognl/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-olingo4/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-olingo4/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openapi-java/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openapi-java/pom.xml
@@ -124,7 +124,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openstack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-openstack/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-opentelemetry/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-opentelemetry/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-optaplanner/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-optaplanner/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho-mqtt5/pom.xml
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-paho/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pdf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pdf/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pg-replication-slot/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pg-replication-slot/pom.xml
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pgevent/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pgevent/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy-ssl/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy-ssl/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http-proxy/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-platform-http/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-protobuf/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-protobuf/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pubnub/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-pubnub/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-quartz/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-quartz/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qute/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-qute/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-reactive-streams/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-reactive-streams/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest-openapi/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest-openapi/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-rest/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saga/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saga/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-salesforce/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-salesforce/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sap-netweaver/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sap-netweaver/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saxon/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-saxon/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servicenow/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servicenow/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servlet/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-servlet/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-shiro/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-shiro/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-artemis-client/pom.xml
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms-qpid-amqp-client/pom.xml
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-artemis-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-artemis-client/pom.xml
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-qpid-amqp-client/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sjms2-qpid-amqp-client/pom.xml
@@ -143,7 +143,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-slack/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-slack/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smallrye-reactive-messaging/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smallrye-reactive-messaging/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smb/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-smb/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-soap/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-soap/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk-hec/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk-hec/pom.xml
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-splunk/pom.xml
@@ -130,7 +130,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-spring-rabbitmq/pom.xml
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sql/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-sql/pom.xml
@@ -150,7 +150,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ssh/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-ssh/pom.xml
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stax/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stax/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stringtemplate/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-stringtemplate/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-swift/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-swift/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syndication/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syndication/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syslog/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-syslog/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tarfile/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tarfile/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-telegram/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-telegram/pom.xml
@@ -146,7 +146,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tika/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-tika/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twilio/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twilio/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twitter/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-twitter/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-univocity-parsers/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-univocity-parsers/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-validator/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-validator/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-velocity/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-velocity/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx-websocket/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx-websocket/pom.xml
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-vertx/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-weather/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-weather/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xj/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xj/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-grouped/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-jaxp/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xml-jaxp/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xmlsecurity/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xmlsecurity/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xpath/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xpath/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xslt-saxon/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-xslt-saxon/pom.xml
@@ -123,7 +123,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-zendesk/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-zendesk/pom.xml
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-camel/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/pom.xml
@@ -222,12 +222,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-cassandra-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-dse/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-dse/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-main/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-main/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-disabled/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-disabled/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-microprofile/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-metrics-microprofile/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-no-mapper/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/cassandra-quarkus-integration-tests-no-mapper/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-cassandra/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/integration-tests/pom.xml
@@ -34,12 +34,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-cxf/bom/pom.xml
+++ b/generated-platform-project/quarkus-cxf/bom/pom.xml
@@ -92,27 +92,27 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-axiom-api-stub</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-bc-stub</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -123,107 +123,107 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>jakarta.jws</groupId>
@@ -458,6 +458,21 @@
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
         <version>4.0.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>5.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>5.2.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>5.2.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.neethi</groupId>

--- a/generated-platform-project/quarkus-cxf/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-cxf/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-cxf-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-cxf/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/pom.xml
@@ -44,12 +44,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client-server/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client-server/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-client-server</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-client-server</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -148,7 +148,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-client-server:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-client-server:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-client</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-client</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -156,7 +156,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -164,7 +164,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-client:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-client:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-fast-infoset/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-fast-infoset/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-fast-infoset</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-fast-infoset</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-fast-infoset:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-fast-infoset:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-hc5/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-hc5/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-hc5</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-hc5</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -145,7 +145,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -153,7 +153,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-hc5:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-hc5:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-metrics/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-metrics/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-metrics</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-metrics</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-metrics:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-metrics:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtls/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtls/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-mtls</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-mtls</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-mtls:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-mtls:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom-awt/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom-awt/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-mtom-awt</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-mtom-awt</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-mtom-awt:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-mtom-awt:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-mtom/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-mtom</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-mtom</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-mtom:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-mtom:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-opentelemetry/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-opentelemetry/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-opentelemetry</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-opentelemetry</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -134,7 +134,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -142,7 +142,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-opentelemetry:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-opentelemetry:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-santuario-xmlsec/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-santuario-xmlsec/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-santuario-xmlsec</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-santuario-xmlsec</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -137,7 +137,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-santuario-xmlsec:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-santuario-xmlsec:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-server/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-server/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-server</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-server</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-server:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-server:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-rm-client/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-rm-client/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-rm-client</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-rm-client</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-ws-rm-server-jvm</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>
@@ -192,7 +192,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -200,7 +200,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-rm-client:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-rm-client:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security-policy/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security-policy/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-security-policy</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-security-policy</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -148,7 +148,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-security-policy:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-security-policy:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-security/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-security</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-security</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -151,7 +151,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -159,7 +159,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-security:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-security:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-trust/pom.xml
+++ b/generated-platform-project/quarkus-cxf/integration-tests/quarkus-cxf-integration-test-ws-trust/pom.xml
@@ -12,12 +12,12 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-trust</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-integration-test-ws-trust</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>
       <scope>test</scope>
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.8.6</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -135,7 +135,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>
@@ -143,7 +143,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-trust:3.8.6</appArtifact>
+                  <appArtifact>io.quarkiverse.cxf:quarkus-cxf-integration-test-ws-trust:${quarkus-cxf.version}</appArtifact>
                 </configuration>
               </execution>
             </executions>

--- a/generated-platform-project/quarkus-debezium/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-debezium/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-debezium-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-integration-tests/pom.xml
@@ -137,7 +137,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-reactive-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-debezium/integration-tests/debezium-quarkus-outbox-reactive-integration-tests/pom.xml
@@ -153,7 +153,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-debezium/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-debezium/integration-tests/pom.xml
@@ -31,12 +31,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-google-cloud-services-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-google-cloud-services/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-google-cloud-services/integration-tests/quarkus-google-cloud-services-main-it/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/integration-tests/quarkus-google-cloud-services-main-it/pom.xml
@@ -152,7 +152,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-operator-sdk/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-operator-sdk-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-operator-sdk/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-operator-sdk/integration-tests/quarkus-operator-sdk-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/integration-tests/quarkus-operator-sdk-integration-tests/pom.xml
@@ -142,7 +142,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-qpid-jms-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/pom.xml
@@ -30,12 +30,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/integration-tests/quarkus-qpid-jms-integration-tests/pom.xml
@@ -142,7 +142,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -9185,27 +9185,27 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-axiom-api-stub</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-bc-stub</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -9216,107 +9216,107 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>3.8.6</version>
+        <version>3.8.7</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.freemarker</groupId>
@@ -21031,17 +21031,17 @@
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.2.1</version>
+        <version>5.2.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/generated-platform-project/quarkus-universe/descriptor/pom.xml
+++ b/generated-platform-project/quarkus-universe/descriptor/pom.xml
@@ -52,7 +52,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-universe-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${project.groupId}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus/descriptor/pom.xml
+++ b/generated-platform-project/quarkus/descriptor/pom.xml
@@ -54,7 +54,7 @@
         </executions>
         <configuration>
           <bomArtifactId>quarkus-bom</bomArtifactId>
-          <quarkusCoreVersion>3.8.6</quarkusCoreVersion>
+          <quarkusCoreVersion>${quarkus.version}</quarkusCoreVersion>
           <platformRelease>
             <platformKey>${platform.key}</platformKey>
             <stream>${platform.stream}</stream>

--- a/generated-platform-project/quarkus/integration-tests/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/pom.xml
@@ -33,12 +33,12 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-integration-test-class-transformer-deployment</artifactId>
-        <version>3.8.6</version>
+        <version>${quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-config-extensions-integration-test-consul/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-config-extensions-integration-test-consul/pom.xml
@@ -125,7 +125,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-agroal/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-agroal/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-app/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test-app/pom.xml
@@ -138,7 +138,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
+++ b/generated-platform-project/quarkus/integration-tests/quarkus-vault-integration-test/pom.xml
@@ -146,7 +146,7 @@
           <plugin>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-maven-plugin</artifactId>
-            <version>3.8.6</version>
+            <version>${quarkus.version}</version>
             <executions>
               <execution>
                 <id>native-image</id>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
              and also at src/main/resources/xslt/amazon-services/test-pom.xsl
              as they might require adjustments. -->
         <quarkus-amazon-services.version>2.12.3</quarkus-amazon-services.version>
-        <quarkus-cxf.version>3.8.6</quarkus-cxf.version>
+        <quarkus-cxf.version>3.8.7</quarkus-cxf.version>
         <quarkus-config-consul.version>2.2.2</quarkus-config-consul.version>
         <quarkus-qpid-jms.version>2.6.1</quarkus-qpid-jms.version>
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>


### PR DESCRIPTION
Quarkus CXF 3.8.7 brings a fix to a security issue https://github.com/quarkiverse/quarkus-cxf/issues/1533

Quarkus CXF 3.8.7 release notes https://docs.quarkiverse.io/quarkus-cxf/dev/release-notes/3.8.7.html