### PR TITLE
Upgrade to the platform generator 0.0.117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <quarkus-vault.version>4.1.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>6.9.1</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.116</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.117</quarkus-platform-bom-generator.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>


### PR DESCRIPTION
Not a critical upgrade. This version of the generator is based on Quarkus 3.15.2.