### PR TITLE
Postpone snapshot deployment

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -2,7 +2,7 @@ name: Quarkus Platform Deploy Snapshots
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
We build at the same time as the Quarkus snapshot deployment and it might be problematic (who knows...).

Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
