### PR TITLE
[3.15] Upgrade Camel Quarkus to 3.15.2

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -120,32 +120,32 @@
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.dstu2</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.dstu3</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.r4</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.r5</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.utilities</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi</groupId>
@@ -759,12 +759,6 @@
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId>
         <version>3.15.3</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
@@ -1153,3447 +1147,3447 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-catalog</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-codegen</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsh-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsh-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-junit5</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-component</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-beans</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-context</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-core</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-activemq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-arangodb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4608,17 +4602,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asn1</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asterisk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -4629,7 +4623,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atom</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4640,17 +4634,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-bedrock</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4661,7 +4655,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4672,7 +4666,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-xray</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4683,7 +4677,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-athena</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4694,7 +4688,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4705,7 +4699,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4716,7 +4710,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ec2</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4727,7 +4721,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ecs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4738,7 +4732,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eks</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4749,7 +4743,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eventbridge</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4760,7 +4754,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-iam</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4771,7 +4765,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4790,7 +4784,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4801,7 +4795,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4812,7 +4806,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-mq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4823,7 +4817,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-msk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4834,7 +4828,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4845,7 +4839,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ses</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4856,7 +4850,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4867,7 +4861,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4878,7 +4872,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sts</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4889,7 +4883,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-translate</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4900,7 +4894,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-cosmosdb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4911,7 +4905,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4922,7 +4916,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4933,7 +4927,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4944,7 +4938,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4955,7 +4949,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4966,7 +4960,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4977,37 +4971,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-barcode</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base64</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5022,22 +5016,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bonita</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5048,22 +5042,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-braintree</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.spotbugs</groupId>
@@ -5078,47 +5072,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cbor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chatscript</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chunk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cm-sms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5129,27 +5123,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-coap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cometd</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-consul</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5160,47 +5154,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchbase</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchdb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5211,17 +5205,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto-pgp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.bouncycastle</groupId>
@@ -5232,37 +5226,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-csv</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-datasonnet</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5289,7 +5283,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -5300,32 +5294,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mongodb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mysql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-postgres</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-sqlserver</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debug</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-digitalocean</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5336,17 +5330,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-disruptor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5357,12 +5351,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dns</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-drill</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -5389,7 +5383,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dropbox</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5400,22 +5394,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ehcache</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5426,7 +5420,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5441,12 +5435,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.mail</groupId>
@@ -5457,7 +5451,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd3</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5480,42 +5474,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-exec</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fastjson</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file-watch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flatpack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5526,7 +5520,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fop</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5541,17 +5535,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-freemarker</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-geocoder</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5562,17 +5556,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-git</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-github</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5599,7 +5593,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-calendar</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5614,7 +5608,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-drive</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5629,7 +5623,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-functions</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5656,7 +5650,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-mail</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5671,7 +5665,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5698,7 +5692,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5729,7 +5723,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-sheets</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5744,7 +5738,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-storage</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5771,7 +5765,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5782,27 +5776,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grok</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5833,12 +5827,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-guava-eventbus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5849,7 +5843,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -5868,12 +5862,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hazelcast</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-headersmap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -5884,27 +5878,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5915,17 +5909,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-smn</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ical</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5936,7 +5930,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iec60870</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5947,17 +5941,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ignite</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.infinispan</groupId>
@@ -5976,52 +5970,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-influxdb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-irc</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-javascript</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -6032,12 +6026,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcache</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcr</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -6048,27 +6042,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups-raft</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6087,7 +6081,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -6106,12 +6100,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jolt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jooq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -6122,12 +6116,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -6142,7 +6136,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>net.thisptr</groupId>
@@ -6157,7 +6151,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-js-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.graalvm.js</groupId>
@@ -6168,92 +6162,92 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsh-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-patch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-validator</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonapi</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonata</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kotlin-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>io.fabric8</groupId>
@@ -6276,57 +6270,57 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-chat</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-core</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-embeddings</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tokenizer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tools</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-web-search</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldif</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-leveldb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -6337,82 +6331,82 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lucene</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lumberjack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lzf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.parsson</groupId>
@@ -6427,7 +6421,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milvus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6466,62 +6460,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb-gridfs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mustache</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mvel</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nitrite</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>javax.validation</groupId>
@@ -6532,7 +6526,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-oaipmh</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6543,12 +6537,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ognl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6559,7 +6553,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6570,7 +6564,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6585,7 +6579,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6600,7 +6594,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openstack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.fge</groupId>
@@ -6615,7 +6609,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>io.grpc</groupId>
@@ -6626,7 +6620,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-optaplanner</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.optaplanner</groupId>
@@ -6645,17 +6639,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pdf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6666,12 +6660,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pg-replication-slot</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pgevent</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.testcontainers</groupId>
@@ -6682,7 +6676,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pinecone</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6705,22 +6699,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-printer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-protobuf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6731,12 +6725,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pubnub</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pulsar</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -6771,7 +6765,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-qdrant</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6794,7 +6788,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6817,32 +6811,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quickfix</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-executor-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-streams</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-redis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6857,27 +6851,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-robotframework</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rss</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6904,12 +6898,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sap-netweaver</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -6920,12 +6914,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -6936,42 +6930,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-shiro</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms2</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>junit</groupId>
@@ -6982,22 +6976,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smpp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snakeyaml</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -7012,7 +7006,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7023,12 +7017,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -7043,17 +7037,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -7064,42 +7058,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stax</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stitch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stomp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stream</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stringtemplate</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-swift</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -7110,22 +7104,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-syslog</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tarfile</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -7136,17 +7130,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-threadpoolfactory-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-thrift</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tika</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.tika</groupId>
@@ -7157,27 +7151,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twilio</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7196,62 +7190,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twitter</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-univocity-parsers</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wasm</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weather</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7262,17 +7256,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-web3j</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wordpress</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7283,7 +7277,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-workday</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7294,7 +7288,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xchange</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7305,27 +7299,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -7340,32 +7334,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmlsecurity</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmpp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -7376,47 +7370,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zendesk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper-master</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7427,7 +7421,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7844,17 +7838,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.asynchttpclient</groupId>
-        <artifactId>async-http-client</artifactId>
-        <version>2.12.4</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcmail-jdk18on</artifactId>
         <version>1.78.1</version>
@@ -7887,72 +7870,72 @@
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-common</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-server</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-api</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-common</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-server</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-session</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.ehcache</groupId>
@@ -8141,7 +8124,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8156,7 +8139,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8167,7 +8150,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jdbc</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8182,7 +8165,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jms</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8197,7 +8180,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8212,7 +8195,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8227,7 +8210,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util</artifactId>
-      <version>3.15.2</version>
+      <version>3.15.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-debezium/pom.xml
@@ -108,7 +108,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
-      <artifactId>camel-quarkus-integration-test-support</artifactId>
+      <artifactId>camel-quarkus-integration-tests-support-mongodb</artifactId>
       <version>${camel-quarkus.version}</version>
       <scope>test</scope>
     </dependency>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -125,32 +125,32 @@
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.dstu2</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.dstu3</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.r4</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.r5</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>org.hl7.fhir.utilities</artifactId>
-        <version>6.3.23</version>
+        <version>6.4.0</version>
       </dependency>
       <dependency>
         <groupId>ca.uhn.hapi</groupId>
@@ -15883,3447 +15883,3447 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-catalog</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-codegen</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-js-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsh-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsh-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-junit5</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kotlin</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-component</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-beans</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-context</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-core</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master-deployment</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-activemq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-arangodb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19338,17 +19338,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asn1</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asterisk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -19359,7 +19359,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atom</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19370,17 +19370,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-bedrock</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19391,7 +19391,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19402,7 +19402,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-xray</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19413,7 +19413,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-athena</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19424,7 +19424,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19435,7 +19435,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19446,7 +19446,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ec2</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19457,7 +19457,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ecs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19468,7 +19468,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eks</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19479,7 +19479,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eventbridge</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19490,7 +19490,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-iam</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19501,7 +19501,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19520,7 +19520,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19531,7 +19531,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19542,7 +19542,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-mq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19553,7 +19553,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-msk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19564,7 +19564,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19575,7 +19575,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ses</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19586,7 +19586,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19597,7 +19597,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19608,7 +19608,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sts</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19619,7 +19619,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-translate</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19630,7 +19630,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-cosmosdb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -19641,7 +19641,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -19652,7 +19652,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -19663,7 +19663,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -19674,7 +19674,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -19685,7 +19685,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -19696,7 +19696,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -19707,37 +19707,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-barcode</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base64</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19752,22 +19752,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bonita</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19778,22 +19778,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-braintree</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.spotbugs</groupId>
@@ -19808,47 +19808,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cbor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chatscript</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chunk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cm-sms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19859,27 +19859,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-coap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cometd</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-consul</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -19890,47 +19890,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchbase</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchdb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19941,17 +19941,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto-pgp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.bouncycastle</groupId>
@@ -19962,37 +19962,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-csv</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-datasonnet</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -20019,7 +20019,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -20030,32 +20030,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mongodb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mysql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-postgres</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-sqlserver</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debug</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-digitalocean</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20066,17 +20066,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-disruptor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -20087,12 +20087,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dns</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-drill</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -20119,7 +20119,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dropbox</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -20130,22 +20130,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ehcache</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20156,7 +20156,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -20171,12 +20171,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.mail</groupId>
@@ -20187,7 +20187,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd3</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -20210,42 +20210,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-exec</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fastjson</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file-watch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flatpack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -20256,7 +20256,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fop</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20271,17 +20271,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-freemarker</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-geocoder</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20292,17 +20292,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-git</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-github</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -20329,7 +20329,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-calendar</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20344,7 +20344,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-drive</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20359,7 +20359,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-functions</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -20386,7 +20386,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-mail</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20401,7 +20401,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -20428,7 +20428,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -20459,7 +20459,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-sheets</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20474,7 +20474,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-storage</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -20501,7 +20501,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20512,27 +20512,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grok</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -20563,12 +20563,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-guava-eventbus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -20579,7 +20579,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -20598,12 +20598,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hazelcast</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-headersmap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -20614,27 +20614,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20645,17 +20645,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-smn</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ical</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20666,7 +20666,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iec60870</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -20677,17 +20677,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ignite</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.infinispan</groupId>
@@ -20706,52 +20706,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-influxdb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-irc</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-javascript</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -20762,12 +20762,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcache</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcr</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -20778,27 +20778,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups-raft</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20817,7 +20817,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -20836,12 +20836,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jolt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jooq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -20852,12 +20852,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -20872,7 +20872,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>net.thisptr</groupId>
@@ -20887,7 +20887,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-js-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.graalvm.js</groupId>
@@ -20898,92 +20898,92 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsh-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-patch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-validator</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonapi</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonata</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kotlin-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>io.fabric8</groupId>
@@ -21006,57 +21006,57 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-chat</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-core</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-embeddings</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tokenizer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tools</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-web-search</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldif</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-leveldb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -21067,82 +21067,82 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lucene</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lumberjack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lzf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.parsson</groupId>
@@ -21157,7 +21157,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milvus</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -21196,62 +21196,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb-gridfs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mustache</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mvel</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nitrite</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>javax.validation</groupId>
@@ -21262,7 +21262,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-oaipmh</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21273,12 +21273,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ognl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21289,7 +21289,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21300,7 +21300,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -21315,7 +21315,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -21330,7 +21330,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openstack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.fge</groupId>
@@ -21345,7 +21345,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>io.grpc</groupId>
@@ -21356,7 +21356,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-optaplanner</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.optaplanner</groupId>
@@ -21375,17 +21375,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pdf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21396,12 +21396,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pg-replication-slot</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pgevent</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.testcontainers</groupId>
@@ -21412,7 +21412,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pinecone</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -21435,22 +21435,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-printer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-protobuf</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -21461,12 +21461,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pubnub</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pulsar</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -21501,7 +21501,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-qdrant</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -21524,7 +21524,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -21547,32 +21547,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quickfix</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-executor-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-streams</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-redis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -21587,27 +21587,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-robotframework</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rss</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -21634,12 +21634,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sap-netweaver</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -21650,12 +21650,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -21666,42 +21666,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-shiro</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms2</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>junit</groupId>
@@ -21712,22 +21712,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smpp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snakeyaml</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -21742,7 +21742,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21753,12 +21753,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -21773,17 +21773,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -21794,42 +21794,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stax</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stitch</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stomp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stream</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stringtemplate</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-swift</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -21840,22 +21840,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-syslog</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tarfile</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -21866,17 +21866,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-threadpoolfactory-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-thrift</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tika</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.tika</groupId>
@@ -21887,27 +21887,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twilio</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21926,62 +21926,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twitter</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-univocity-parsers</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wasm</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weather</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -21992,17 +21992,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-web3j</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wordpress</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -22013,7 +22013,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-workday</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -22024,7 +22024,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xchange</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -22035,27 +22035,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -22070,32 +22070,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmlsecurity</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmpp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -22106,47 +22106,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zendesk</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper-master</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -22157,7 +22157,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -23184,72 +23184,72 @@
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-common</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-server</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-api</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-common</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-server</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-session</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
@@ -25136,7 +25136,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -25151,7 +25151,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -25162,7 +25162,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jdbc</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -25177,7 +25177,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jms</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -25192,7 +25192,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -25207,7 +25207,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -25222,7 +25222,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>6.1.12</version>
+        <version>6.1.16</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkus.version>3.15.3</quarkus.version>
         <quarkus-bom.version>${quarkus.version}</quarkus-bom.version>
 
-        <camel-quarkus.version>3.15.1</camel-quarkus.version>
+        <camel-quarkus.version>3.15.2</camel-quarkus.version>
         <camel-quarkus-test-list.version>${camel-quarkus.version}</camel-quarkus-test-list.version>
 
         <!-- If you made changes to the integration tests pom of Amazon Services,


### PR DESCRIPTION
This PR isn't addressing any specific compatibility concerns.

I know there's a process in place with branch freezes etc. But I was hoping we could get this merged instead of waiting until the next patch release in March.
