### PR TITLE
Revert the Fault Tolerance override hack

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -14526,47 +14526,47 @@
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-api</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-core</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-kotlin</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-vertx</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -8870,47 +8870,47 @@
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-api</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-autoconfig-core</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-context-propagation</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-core</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-kotlin</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-mutiny</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-tracing-propagation</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance-vertx</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance</artifactId>
-        <version>6.4.3</version>
+        <version>6.4.2</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -183,16 +183,6 @@
                                 <bom>io.quarkus:quarkus-bom:${quarkus-bom.version}</bom>
                                 <dependencyManagement>
                                     <!-- Extra constraints -->
-                                    <!-- TODO: remove SmallRye Fault Tolerance override before next Platform release -->
-                                    <dependency>io.smallrye:smallrye-fault-tolerance:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-api:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-autoconfig-core:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-core:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-context-propagation:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-kotlin:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-mutiny:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-tracing-propagation:6.4.3</dependency>
-                                    <dependency>io.smallrye:smallrye-fault-tolerance-vertx:6.4.3</dependency>
                                     <!-- Consul config -->
                                     <dependency>io.quarkiverse.config:quarkus-config-consul:${quarkus-config-consul.version}</dependency>
                                     <dependency>io.quarkiverse.config:quarkus-config-consul-deployment:${quarkus-config-consul.version}</dependency>


### PR DESCRIPTION
This reverts commit 183fef094559bda07ea24d31d38e0fa4ac46f0b0.

Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
