### PR TITLE
Add io.quarkus:quarkus-platform-bom-maven-plugin to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       timezone: Europe/Paris
     allow:
       - dependency-name: org.jboss:jboss-parent
+      - dependency-name: io.quarkus:quarkus-platform-bom-maven-plugin
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
