### PR TITLE
Enforce Maven plugins versions

### DIFF
--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -49,6 +49,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-amazon-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/bom/pom.xml
@@ -2911,6 +2911,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
@@ -86,6 +86,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -8890,6 +8890,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-cassandra/bom/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/bom/pom.xml
@@ -187,6 +187,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-cxf/bom/pom.xml
+++ b/generated-platform-project/quarkus-cxf/bom/pom.xml
@@ -588,6 +588,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-debezium/bom/pom.xml
+++ b/generated-platform-project/quarkus-debezium/bom/pom.xml
@@ -156,6 +156,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
@@ -4673,6 +4673,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-operator-sdk/bom/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/bom/pom.xml
@@ -111,6 +111,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -81,6 +81,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -27004,6 +27004,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -11332,6 +11332,26 @@
     <profile>
       <id>release</id>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.1.4</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.2.7</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>3.11.2</version>
+            </plugin>
+            <plugin>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,10 @@
         <quarkus-operator-sdk.version>7.2.0</quarkus-operator-sdk.version>
 
         <quarkus-platform-bom-generator.version>0.0.121</quarkus-platform-bom-generator.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <maven-plugin-plugin.version>3.15.1</maven-plugin-plugin.version>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>
@@ -717,6 +721,30 @@
                 <module>generated-platform-project</module>
             </modules>
             <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-deploy-plugin</artifactId>
+                            <version>${maven-deploy-plugin.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-gpg-plugin</artifactId>
+                            <version>${maven-gpg-plugin.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <version>${maven-javadoc-plugin.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-source-plugin</artifactId>
+                            <version>${maven-source-plugin.version}</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <!-- Given that the generated platform project is included as a module in this profile,
                          the platform invoker goal becomes redundant and can be disabled -->


### PR DESCRIPTION
This will make the build more stable and avoid warnings on release.

Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
