### PR TITLE
[3.20] Upgrade to Camel Quarkus 3.20.2

### DIFF
--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -650,7 +650,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.4</version>
+        <version>1.11.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -779,6 +779,11 @@
             <artifactId>checker-qual</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-semconv</artifactId>
+        <version>1.29.0-alpha</version>
       </dependency>
       <dependency>
         <groupId>io.perfmark</groupId>
@@ -1207,3467 +1212,3467 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-catalog</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fury-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fury</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-codegen</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolokia-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolokia</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-junit5</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-observability-services-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-observability-services</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-component</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smooks-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smooks</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-pubsub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-pubsub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-beans</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-context</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-core</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-activemq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-arangodb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4682,17 +4687,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asn1</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asterisk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -4703,7 +4708,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atom</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4714,17 +4719,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-bedrock</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4735,7 +4740,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4746,7 +4751,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-xray</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4757,7 +4762,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-athena</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4768,7 +4773,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4779,7 +4784,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4794,7 +4799,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ec2</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4805,7 +4810,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ecs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4816,7 +4821,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eks</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4827,7 +4832,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eventbridge</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4838,7 +4843,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-iam</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4849,7 +4854,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -4872,7 +4877,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4883,7 +4888,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4894,7 +4899,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-mq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4905,7 +4910,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-msk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4916,7 +4921,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4927,7 +4932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ses</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4938,7 +4943,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4949,7 +4954,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4960,7 +4965,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sts</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4971,7 +4976,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-translate</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -4982,7 +4987,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-cosmosdb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -4993,7 +4998,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -5004,7 +5009,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -5015,7 +5020,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -5026,7 +5031,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -5037,7 +5042,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -5048,7 +5053,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -5059,37 +5064,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-barcode</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base64</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -5104,22 +5109,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bonita</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5130,22 +5135,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-braintree</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.cassandra</groupId>
@@ -5156,47 +5161,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cbor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chatscript</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chunk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cm-sms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5207,27 +5212,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-coap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cometd</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-consul</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5238,47 +5243,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchbase</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchdb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5289,17 +5294,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto-pgp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.bouncycastle</groupId>
@@ -5310,37 +5315,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-csv</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-datasonnet</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -5371,7 +5376,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -5382,32 +5387,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mongodb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mysql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-postgres</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-sqlserver</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debug</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-digitalocean</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5418,17 +5423,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-disruptor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5439,12 +5444,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dns</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-drill</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -5471,7 +5476,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dropbox</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5482,22 +5487,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ehcache</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5508,7 +5513,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5523,7 +5528,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.mail</groupId>
@@ -5534,7 +5539,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd3</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5557,42 +5562,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-exec</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fastjson</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file-watch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flatpack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -5603,7 +5608,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fop</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5618,17 +5623,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-freemarker</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fury</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5639,7 +5644,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-geocoder</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5650,17 +5655,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-git</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-github</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5687,7 +5692,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-calendar</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5702,7 +5707,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-drive</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5717,7 +5722,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-functions</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5748,7 +5753,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-mail</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5763,7 +5768,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5790,7 +5795,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5825,7 +5830,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-sheets</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5840,7 +5845,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-storage</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5867,7 +5872,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -5878,17 +5883,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grok</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -5919,12 +5924,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-guava-eventbus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -5935,7 +5940,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -5954,12 +5959,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hazelcast</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-headersmap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -5970,27 +5975,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6001,17 +6006,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-smn</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ical</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6022,7 +6027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iec60870</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -6033,17 +6038,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ignite</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.infinispan</groupId>
@@ -6062,52 +6067,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-influxdb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-irc</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-javascript</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -6118,12 +6123,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcache</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcr</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -6134,27 +6139,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups-raft</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6173,7 +6178,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -6192,12 +6197,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jolt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jooq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -6208,12 +6213,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -6228,7 +6233,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>net.thisptr</groupId>
@@ -6243,82 +6248,82 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-patch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-validator</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonapi</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonata</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>io.fabric8</groupId>
@@ -6341,57 +6346,57 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-chat</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-core</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-embeddings</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tokenizer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tools</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-web-search</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldif</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-leveldb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -6402,82 +6407,82 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lucene</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lumberjack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lzf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.parsson</groupId>
@@ -6492,7 +6497,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milvus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6531,62 +6536,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb-gridfs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mustache</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mvel</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nitrite</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>javax.validation</groupId>
@@ -6597,7 +6602,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-oaipmh</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6608,12 +6613,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ognl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6624,7 +6629,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6635,7 +6640,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6650,7 +6655,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6665,7 +6670,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openstack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.fge</groupId>
@@ -6680,7 +6685,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>io.grpc</groupId>
@@ -6691,7 +6696,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-optaplanner</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.optaplanner</groupId>
@@ -6710,17 +6715,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pdf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -6731,12 +6736,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pg-replication-slot</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pgevent</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.testcontainers</groupId>
@@ -6747,7 +6752,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pinecone</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6770,22 +6775,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-printer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-protobuf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6796,12 +6801,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pubnub</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pulsar</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -6836,7 +6841,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-qdrant</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6859,7 +6864,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6882,32 +6887,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quickfix</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-executor-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-streams</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-redis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -6922,27 +6927,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-robotframework</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rss</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -6969,12 +6974,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sap-netweaver</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -6985,12 +6990,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -7001,42 +7006,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-shiro</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms2</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>junit</groupId>
@@ -7047,7 +7052,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smooks</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -7066,22 +7071,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smpp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snakeyaml</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -7096,12 +7101,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-solr</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7112,12 +7117,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -7132,17 +7137,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -7153,42 +7158,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stax</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stitch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stomp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stream</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stringtemplate</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-swift</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -7199,22 +7204,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-syslog</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tarfile</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -7225,42 +7230,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-threadpoolfactory-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-thrift</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tika</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twilio</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7279,62 +7284,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twitter</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-univocity-parsers</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wasm</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weather</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7345,17 +7350,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-web3j</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wordpress</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7366,7 +7371,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-workday</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7377,7 +7382,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xchange</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7388,27 +7393,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -7423,32 +7428,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmlsecurity</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmpp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -7459,47 +7464,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zendesk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper-master</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7510,7 +7515,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -7890,10 +7895,6 @@
         <version>4.0.0</version>
         <exclusions>
           <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
           </exclusion>
@@ -7982,72 +7983,72 @@
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-common</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-server</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-api</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-common</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-server</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-session</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.ehcache</groupId>
@@ -8219,7 +8220,7 @@
       <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-redis</artifactId>
-        <version>3.4.5</version>
+        <version>3.4.7</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8246,7 +8247,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8261,7 +8262,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8272,7 +8273,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jdbc</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8287,7 +8288,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jms</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8302,7 +8303,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8317,7 +8318,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -8332,7 +8333,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -5621,7 +5621,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.4</version>
+        <version>1.11.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -7672,6 +7672,11 @@
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-sdk</artifactId>
         <version>1.44.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-semconv</artifactId>
+        <version>1.29.0-alpha</version>
       </dependency>
       <dependency>
         <groupId>io.perfmark</groupId>
@@ -14222,3467 +14227,3467 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-activemq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-amqp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-arangodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-as2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asn1</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-asterisk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-atom</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-attachments</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-avro</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-bedrock</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-secrets-manager</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws-xray</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-athena</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-cw</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ddb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ec2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ecs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eks</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-eventbridge</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-iam</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kinesis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-kms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-lambda</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-mq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-msk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-s3</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-ses</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sns</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sqs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-sts</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-aws2-translate</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-cosmosdb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-eventhubs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-key-vault</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-servicebus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-blob</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-datalake</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-azure-storage-queue</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-barcode</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-base64</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean-validator</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bean</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-beanio</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bindy</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-bonita</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-box</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-braintree</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-browse</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-caffeine</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cassandraql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-catalog</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cbor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chatscript</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-chunk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cli-connector</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cloudevents</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cm-sms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-coap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cometd</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-console</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-consul</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-controlbus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-cloud</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-core</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchbase</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-couchdb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cron</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto-pgp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-crypto</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csimple</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-csv</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-cxf-soap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataformat</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dataset</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-datasonnet</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mongodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-mysql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-postgres</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debezium-sqlserver</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-debug</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-digitalocean</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-direct</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-disruptor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-djl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dns</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-drill</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dropbox</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-dsl-modeline</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ehcache</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch-rest-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-elasticsearch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-etcd3</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-exec</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fastjson</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fhir</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-cluster-service</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file-watch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-file</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flatpack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-flink</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fop</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-freemarker</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ftp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fury-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-fury</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-geocoder</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-git</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-github</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-bigquery</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-calendar</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-drive</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-functions</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-mail</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-pubsub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-secret-manager</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-sheets</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-google-storage</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-graphql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grok</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-groovy</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-codegen</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-grpc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-gson</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-guava-eventbus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hashicorp-vault</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hazelcast</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-headersmap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-hl7</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-common</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-huaweicloud-smn</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ical</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-iec60870</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ignite</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-infinispan</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-influxdb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-irc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-avro</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson-protobuf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jackson</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jacksonxml</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jasypt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-java-joor-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-javascript</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jaxb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcache</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jcr</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jdbc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jfr</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups-raft</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jgroups</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jira</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolokia-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolokia</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jolt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jooq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-joor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jpa</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jslt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-patch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-json-validator</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonapi</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonata</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jsonpath</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jt400</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-jta</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-junit5</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kafka</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kamelet</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-consumer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative-producer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-knative</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-cluster-service</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kubernetes</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-kudu</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-chat</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-embeddings</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tokenizer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-tools</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j-web-search</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-langchain4j</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-language</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ldif</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-leveldb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-log</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lra</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lucene</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lumberjack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-lzf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail-microsoft-oauth</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mail</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-management</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mapstruct</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-master</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-micrometer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-microprofile-health</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-milvus</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-minio</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mllp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mock</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb-gridfs</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mongodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mustache</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mvel</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-mybatis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nats</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-netty</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-nitrite</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-oaipmh</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-observability-services-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-observability-services</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ognl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-olingo4</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openapi-java</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opensearch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-openstack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-optaplanner</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho-mqtt5</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-paho</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pdf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pg-replication-slot</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pgevent</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pinecone</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-platform-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-printer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-protobuf</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pubnub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-pulsar</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qdrant</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quartz</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-quickfix</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-component</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-qute</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-executor</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-reactive-streams</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-redis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ref</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest-openapi</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rest</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-robotframework</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-rss</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saga</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-salesforce</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sap-netweaver</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-saxon</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-scheduler</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-schematron</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-seda</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servicenow</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-servlet</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-shiro</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sjms</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-slack</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smallrye-reactive-messaging</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smooks-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smooks</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-smpp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snakeyaml</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-snmp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-soap</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-solr</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk-hec</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-splunk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-rabbitmq</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-spring-redis</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-sql</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-ssh</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stax</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stitch</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stomp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stream</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stringtemplate</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-stub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-ahc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws2</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-aws</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core-http-client-vertx</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-azure-core</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-bouncycastle</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-commons-logging</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-consul-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-debezium</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-cloud</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-http-client</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-pubsub-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-google-pubsub</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient5</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-httpclient</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jackson-dataformat-xml</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jdbc</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-jetty</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-language</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mail</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-mongodb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-reactor-netty</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-retrofit</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-beans</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-context</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-core</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-spring</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-swagger</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-webhook</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-support-xalan</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-swift</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-syslog</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tarfile</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-telegram</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-threadpoolfactory-vertx</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-thrift</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-tika</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-timer</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twilio</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-twitter</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-univocity-parsers</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-validator</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-velocity</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-http</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx-websocket</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-vertx</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wasm</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-weather</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-web3j</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-wordpress</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-workday</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xchange</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xj</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-io-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxb</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xml-jaxp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmlsecurity</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xmpp</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xpath</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt-saxon</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-xslt</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-dsl</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-yaml-io</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zendesk</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zip-deflater</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zipfile</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master-deployment</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper-master</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-zookeeper</artifactId>
-        <version>3.20.1</version>
+        <version>3.20.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-activemq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-arangodb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17697,17 +17702,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-as2</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asn1</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-asterisk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -17718,7 +17723,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-atom</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17729,17 +17734,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-bedrock</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17750,7 +17755,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17761,7 +17766,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-xray</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17772,7 +17777,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-athena</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17783,7 +17788,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17794,7 +17799,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17809,7 +17814,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ec2</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17820,7 +17825,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ecs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17831,7 +17836,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eks</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17842,7 +17847,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-eventbridge</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17853,7 +17858,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-iam</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17864,7 +17869,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -17887,7 +17892,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17898,7 +17903,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17909,7 +17914,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-mq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17920,7 +17925,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-msk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17931,7 +17936,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17942,7 +17947,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ses</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17953,7 +17958,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17964,7 +17969,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17975,7 +17980,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sts</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17986,7 +17991,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-translate</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -17997,7 +18002,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-cosmosdb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -18008,7 +18013,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -18019,7 +18024,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -18030,7 +18035,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -18041,7 +18046,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -18052,7 +18057,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -18063,7 +18068,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.azure</groupId>
@@ -18074,37 +18079,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-barcode</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base64</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -18119,22 +18124,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bonita</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-box</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18145,22 +18150,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-braintree</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-caffeine</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.cassandra</groupId>
@@ -18171,47 +18176,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cbor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chatscript</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-chunk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cm-sms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18222,27 +18227,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-coap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cometd</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-consul</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -18253,47 +18258,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchbase</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-couchdb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18304,17 +18309,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto-pgp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.bouncycastle</groupId>
@@ -18325,37 +18330,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-csv</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-datasonnet</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -18386,7 +18391,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -18397,32 +18402,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mongodb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-mysql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-postgres</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-sqlserver</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debug</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-digitalocean</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18433,17 +18438,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-disruptor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -18454,12 +18459,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dns</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-drill</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -18486,7 +18491,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dropbox</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -18497,22 +18502,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ehcache</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18523,7 +18528,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -18538,7 +18543,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.mail</groupId>
@@ -18549,7 +18554,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-etcd3</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -18572,42 +18577,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-exec</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fastjson</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file-watch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flatpack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -18618,7 +18623,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fop</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18633,17 +18638,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-freemarker</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fury</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -18654,7 +18659,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-geocoder</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18665,17 +18670,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-git</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-github</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -18702,7 +18707,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-calendar</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18717,7 +18722,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-drive</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18732,7 +18737,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-functions</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -18763,7 +18768,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-mail</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18778,7 +18783,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -18805,7 +18810,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -18840,7 +18845,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-sheets</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18855,7 +18860,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-storage</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -18882,7 +18887,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -18893,17 +18898,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grok</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -18934,12 +18939,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-guava-eventbus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -18950,7 +18955,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -18969,12 +18974,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hazelcast</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-headersmap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -18985,27 +18990,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19016,17 +19021,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-huaweicloud-smn</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ical</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19037,7 +19042,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-iec60870</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -19048,17 +19053,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ignite</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.infinispan</groupId>
@@ -19077,52 +19082,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-influxdb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-irc</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-javascript</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -19133,12 +19138,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcache</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jcr</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -19149,27 +19154,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups-raft</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jgroups</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19188,7 +19193,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -19207,12 +19212,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jolt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jooq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -19223,12 +19228,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -19243,7 +19248,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>net.thisptr</groupId>
@@ -19258,82 +19263,82 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-patch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-json-validator</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonapi</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonata</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>io.fabric8</groupId>
@@ -19356,57 +19361,57 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-chat</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-core</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-embeddings</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tokenizer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-tools</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-langchain4j-web-search</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldif</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-leveldb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -19417,82 +19422,82 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lucene</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lumberjack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lzf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.parsson</groupId>
@@ -19507,7 +19512,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milvus</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -19546,62 +19551,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb-gridfs</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mustache</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mvel</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nitrite</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>javax.validation</groupId>
@@ -19612,7 +19617,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-oaipmh</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19623,12 +19628,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ognl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19639,7 +19644,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19650,7 +19655,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -19665,7 +19670,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -19680,7 +19685,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openstack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.github.fge</groupId>
@@ -19695,7 +19700,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>io.grpc</groupId>
@@ -19706,7 +19711,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-optaplanner</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.optaplanner</groupId>
@@ -19725,17 +19730,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pdf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -19746,12 +19751,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pg-replication-slot</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pgevent</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.testcontainers</groupId>
@@ -19762,7 +19767,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pinecone</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -19785,22 +19790,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-printer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-protobuf</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -19811,12 +19816,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pubnub</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-pulsar</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.activation</groupId>
@@ -19851,7 +19856,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-qdrant</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -19874,7 +19879,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -19897,32 +19902,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quickfix</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-executor-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-reactive-streams</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-redis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -19937,27 +19942,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-robotframework</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rss</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.android</groupId>
@@ -19984,12 +19989,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sap-netweaver</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -20000,12 +20005,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-schematron</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -20016,42 +20021,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-shiro</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms2</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sjms</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>junit</groupId>
@@ -20062,7 +20067,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smooks</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -20081,22 +20086,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smpp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snakeyaml</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -20111,12 +20116,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-solr</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20127,12 +20132,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -20147,17 +20152,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -20168,42 +20173,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stax</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stitch</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stomp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stream</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stringtemplate</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-swift</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -20214,22 +20219,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-syslog</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tarfile</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.camel</groupId>
@@ -20240,42 +20245,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-threadpoolfactory-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-thrift</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tika</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twilio</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20294,62 +20299,62 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-twitter</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-univocity-parsers</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wasm</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-weather</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20360,17 +20365,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-web3j</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-wordpress</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -20381,7 +20386,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-workday</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -20392,7 +20397,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xchange</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -20403,27 +20408,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>com.sun.xml.bind</groupId>
@@ -20438,32 +20443,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmlsecurity</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xmpp</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>
@@ -20474,47 +20479,47 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zendesk</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper-master</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -20525,7 +20530,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zookeeper</artifactId>
-        <version>4.10.4</version>
+        <version>4.10.6</version>
         <exclusions>
           <exclusion>
             <groupId>org.checkerframework</groupId>
@@ -21371,10 +21376,6 @@
         <version>4.0.0</version>
         <exclusions>
           <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
           </exclusion>
@@ -21575,72 +21576,72 @@
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-common</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-core-server</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-api</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-common</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
         <artifactId>jetty-websocket-jetty-server</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-io</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-session</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util-ajax</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-util</artifactId>
-        <version>12.0.19</version>
+        <version>12.0.21</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
@@ -23475,7 +23476,7 @@
       <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-redis</artifactId>
-        <version>3.4.5</version>
+        <version>3.4.7</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -23502,7 +23503,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -23517,7 +23518,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -23528,7 +23529,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jdbc</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -23543,7 +23544,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-jms</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -23558,7 +23559,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-messaging</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -23573,7 +23574,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>
@@ -23588,7 +23589,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>6.2.6</version>
+        <version>6.2.8</version>
         <exclusions>
           <exclusion>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <quarkus.version>3.20.1</quarkus.version>
         <quarkus-bom.version>${quarkus.version}</quarkus-bom.version>
 
-        <camel-quarkus.version>3.20.1</camel-quarkus.version>
+        <camel-quarkus.version>3.20.2</camel-quarkus.version>
         <camel-quarkus-test-list.version>${camel-quarkus.version}</camel-quarkus-test-list.version>
 
         <!-- If you made changes to the integration tests pom of Amazon Services,


### PR DESCRIPTION
https://camel.apache.org/blog/2025/07/camel-quarkus-release-3.20.2/