### PR TITLE
Move Ecosystem CI to Java 21

### DIFF
--- a/.github/workflows/quarkus-snapshots.yml
+++ b/.github/workflows/quarkus-snapshots.yml
@@ -10,7 +10,7 @@ env:
   LANG: en_US.UTF-8
   ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
   ECOSYSTEM_CI_REPO_FILE: context.yaml
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
 
   #########################
   # Repo specific setting #


### PR DESCRIPTION
Due to problems with Google Cloud Services

Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
