### PR TITLE
Upgrade to Quarkiverse Google Cloud Services extension pack 2.18.0

### DIFF
--- a/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
@@ -4214,7 +4214,7 @@
       <dependency>
         <groupId>com.google.firebase</groupId>
         <artifactId>firebase-admin</artifactId>
-        <version>9.4.3</version>
+        <version>9.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -4508,144 +4508,139 @@
         <version>0.31.1</version>
       </dependency>
       <dependency>
-        <groupId>io.perfmark</groupId>
-        <artifactId>perfmark-api</artifactId>
-        <version>0.27.0</version>
-      </dependency>
-      <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigquery-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigquery</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigtable-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigtable</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-common-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-common-grpc</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-common</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-admin-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-admin</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-devservices-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-devservices</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-realtime-database-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-realtime-database</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firestore-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firestore</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-logging-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-logging</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-pubsub-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-pubsub</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-secret-manager-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-secret-manager</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-spanner-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-spanner</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-storage-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-storage</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-vertex-ai-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-vertex-ai</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>org.conscrypt</groupId>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -5163,7 +5163,7 @@
       <dependency>
         <groupId>com.google.firebase</groupId>
         <artifactId>firebase-admin</artifactId>
-        <version>9.4.3</version>
+        <version>9.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -8576,137 +8576,137 @@
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigquery-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigquery</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigtable-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-bigtable</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-common-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-common-grpc</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-common</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-admin-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-admin</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-devservices-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-devservices</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-realtime-database-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firebase-realtime-database</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firestore-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-firestore</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-logging-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-logging</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-pubsub-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-pubsub</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-secret-manager-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-secret-manager</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-spanner-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-spanner</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-storage-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-storage</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-vertex-ai-deployment</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
         <artifactId>quarkus-google-cloud-vertex-ai</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.groovy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <drools-quarkus.version>8.33.0.Final</drools-quarkus.version>
         <optaplanner-quarkus.version>9.37.0.Final</optaplanner-quarkus.version>
 
-        <quarkus-google-cloud-services.version>2.17.1</quarkus-google-cloud-services.version>
+        <quarkus-google-cloud-services.version>2.18.0</quarkus-google-cloud-services.version>
         <quarkus-vault.version>4.3.0</quarkus-vault.version>
         <quarkus-operator-sdk.version>7.2.0</quarkus-operator-sdk.version>
 


### PR DESCRIPTION
@gsmet this new release is based on Quarkus 3.25 and contains the fix for the firestore container that fails tests.

Tell me if I need to create micro releases for older versions of Quarkus with this fix.