### PR TITLE
[3.15] Disable Google Cloud Services IT in back branches

### DIFF
--- a/generated-platform-project/quarkus-google-cloud-services/integration-tests/quarkus-google-cloud-services-main-it/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/integration-tests/quarkus-google-cloud-services-main-it/pom.xml
@@ -10,6 +10,9 @@
   </parent>
   <artifactId>quarkus-google-cloud-services-main-it</artifactId>
   <name>Quarkus Platform - GoogleCloudServices - Integration Tests - quarkus-google-cloud-services-main-it</name>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>io.quarkiverse.googlecloudservices</groupId>
@@ -161,6 +164,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
+                  <skip>true</skip>
                   <appArtifact>io.quarkiverse.googlecloudservices:quarkus-google-cloud-services-main-it:${quarkus-google-cloud-services.version}</appArtifact>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -535,6 +535,7 @@
                                     </defaultTestConfig>
                                     <tests>
                                         <test>
+                                            <skip>true</skip>
                                             <artifact>io.quarkiverse.googlecloudservices:quarkus-google-cloud-services-main-it:${quarkus-google-cloud-services.version}</artifact>
                                         </test>
                                     </tests>


### PR DESCRIPTION
The Dev Services are failing because of a problem with the wait strategy (I think):

INFO  [tc.gcr.io/.com/cloudsdktool/google-cloud-cli:latest] (build-6) Container gcr.io/google.com/cloudsdktool/google-cloud-cli:latest is starting: 62645fb62ca59eb8791e5f266c1c032d91fb1b7f61e50caed4c02d8e6136a59c INFO  [tc.gcr.io/.com/cloudsdktool/google-cloud-cli:latest] (build-30) Container gcr.io/google.com/cloudsdktool/google-cloud-cli:latest is starting: a61ecd91dc1851b48ad78bde430b2749204f0a33437e651cc9bd422f308c2d61 INFO  [tc.gcr.io/.com/cloudsdktool/google-cloud-cli:latest] (build-36) Container gcr.io/google.com/cloudsdktool/google-cloud-cli:latest is starting: 1d433d4a2b29fd412686739f4471ae3a67bdaacd5fac36fd04e7c6f91c0bd2f3 INFO  [tc.gcr.io/.com/cloudsdktool/google-cloud-cli:latest] (build-36) Container gcr.io/google.com/cloudsdktool/google-cloud-cli:latest started in PT1.277562198S INFO  [tc.gcr.io/.com/cloudsdktool/google-cloud-cli:latest] (build-6) Container gcr.io/google.com/cloudsdktool/google-cloud-cli:latest started in PT1.968871192S ERROR [tc.gcr.io/.com/cloudsdktool/google-cloud-cli:latest] (build-30) Could not start container: java.lang.IllegalStateException: Wait strategy failed. Container exited with code 1
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:525)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:346)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:336)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
	at io.quarkiverse.googlecloudservices.firestore.deployment.FirestoreDevServiceProcessor.startContainer(FirestoreDevServiceProcessor.java:124)
	at io.quarkiverse.googlecloudservices.firestore.deployment.FirestoreDevServiceProcessor.startContainerIfAvailable(FirestoreDevServiceProcessor.java:103)
	at io.quarkiverse.googlecloudservices.firestore.deployment.FirestoreDevServiceProcessor.start(FirestoreDevServiceProcessor.java:60)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:499)
Caused by: org.testcontainers.containers.ContainerLaunchException: Timed out waiting for log output matching '.*running.*$'
	at org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy.waitUntilReady(LogMessageWaitStrategy.java:47)
	at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:52)
	at org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:909)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:492)

(cherry picked from commit 61c695774f36e827ca54cd7b800d2617c4c2cbfe)

Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
