### PR TITLE
Upgrade to platform generator 0.0.123

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <quarkus-vault.version>4.2.1</quarkus-vault.version>
         <quarkus-operator-sdk.version>7.1.4</quarkus-operator-sdk.version>
 
-        <quarkus-platform-bom-generator.version>0.0.118</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.123</quarkus-platform-bom-generator.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>


### PR DESCRIPTION
It needs to be at least 0.0.119 to include https://github.com/quarkusio/quarkus-platform-bom-generator/pull/359