### PR TITLE
Update Quarkus Qute Web to 3.4.4

### DIFF
--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -9670,12 +9670,12 @@
       <dependency>
         <groupId>io.quarkiverse.qute.web</groupId>
         <artifactId>quarkus-qute-web-deployment</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.4</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.qute.web</groupId>
         <artifactId>quarkus-qute-web</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.4</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -2837,12 +2837,12 @@
       <dependency>
         <groupId>io.quarkiverse.qute.web</groupId>
         <artifactId>quarkus-qute-web-deployment</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.4</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.qute.web</groupId>
         <artifactId>quarkus-qute-web</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.4</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.vault</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <quarkus-blaze-persistence.version>1.6.16</quarkus-blaze-persistence.version>
         <quarkus-cassandra-client.version>1.3.0</quarkus-cassandra-client.version>
         <quarkus-cassandra-client-test.version>${quarkus-cassandra-client.version}</quarkus-cassandra-client-test.version>
-        <quarkus-qute-web.version>3.3.0</quarkus-qute-web.version>
+        <quarkus-qute-web.version>3.4.4</quarkus-qute-web.version>
 
         <drools-quarkus.version>8.33.0.Final</drools-quarkus.version>
         <optaplanner-quarkus.version>9.37.0.Final</optaplanner-quarkus.version>


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus/issues/49700

@mkouba @ia3andy make sure you update the version in the Platform when you release because the version we had here was outdated and incompatible with recent Quarkus versions.