### PR TITLE
Revert "Bump org.jboss:jboss-parent from 49 to 50"

### DIFF
--- a/generated-platform-project/pom.xml
+++ b/generated-platform-project/pom.xml
@@ -73,7 +73,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -110,7 +110,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-amazon-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-amazon-services/bom/pom.xml
@@ -3024,7 +3024,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -3061,7 +3061,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
@@ -109,7 +109,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -146,7 +146,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-camel/bom/pom.xml
+++ b/generated-platform-project/quarkus-camel/bom/pom.xml
@@ -9084,7 +9084,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -9121,7 +9121,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-cassandra/bom/pom.xml
+++ b/generated-platform-project/quarkus-cassandra/bom/pom.xml
@@ -220,7 +220,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -257,7 +257,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-cxf/bom/pom.xml
+++ b/generated-platform-project/quarkus-cxf/bom/pom.xml
@@ -611,7 +611,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -648,7 +648,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-debezium/bom/pom.xml
+++ b/generated-platform-project/quarkus-debezium/bom/pom.xml
@@ -179,7 +179,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -216,7 +216,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
+++ b/generated-platform-project/quarkus-google-cloud-services/bom/pom.xml
@@ -4691,7 +4691,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -4728,7 +4728,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-langchain4j/bom/pom.xml
+++ b/generated-platform-project/quarkus-langchain4j/bom/pom.xml
@@ -952,7 +952,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -989,7 +989,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-operator-sdk/bom/pom.xml
+++ b/generated-platform-project/quarkus-operator-sdk/bom/pom.xml
@@ -134,7 +134,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -171,7 +171,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
+++ b/generated-platform-project/quarkus-qpid-jms/bom/pom.xml
@@ -104,7 +104,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -141,7 +141,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -28207,7 +28207,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -28244,7 +28244,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/generated-platform-project/quarkus/bom/pom.xml
+++ b/generated-platform-project/quarkus/bom/pom.xml
@@ -11420,7 +11420,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -11457,7 +11457,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.8</version>
+            <version>3.2.7</version>
             <configuration>
               <bestPractices>true</bestPractices>
               <useAgent>false</useAgent>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>50</version>
+        <version>49</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The new parent is causing issues, the most problematic one being it enforces the Nexus 3 plugin for releasing.

This reverts commit 3340b07ddf99b62e891100152ad3daf522754298.

Make sure that you have run `./mvnw -Dsync` and included the changes in your pull request (preferably in the same commit, unless it makes sense to do otherwise).

Thanks!
