### PR TITLE
Upgrade to Blaze-Persistence 1.6.18 with hibernate 7.2 support.

### DIFF
--- a/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/bom/pom.xml
@@ -63,22 +63,22 @@
       <dependency>
         <groupId>com.blazebit</groupId>
         <artifactId>blaze-persistence-entity-view-processor-jakarta</artifactId>
-        <version>1.6.17</version>
+        <version>1.6.18</version>
       </dependency>
       <dependency>
         <groupId>com.blazebit</groupId>
-        <artifactId>blaze-persistence-integration-hibernate-7.1</artifactId>
-        <version>1.6.17</version>
+        <artifactId>blaze-persistence-integration-hibernate-7.2</artifactId>
+        <version>1.6.18</version>
       </dependency>
       <dependency>
         <groupId>com.blazebit</groupId>
         <artifactId>blaze-persistence-integration-quarkus-3-deployment</artifactId>
-        <version>1.6.17</version>
+        <version>1.6.18</version>
       </dependency>
       <dependency>
         <groupId>com.blazebit</groupId>
         <artifactId>blaze-persistence-integration-quarkus-3</artifactId>
-        <version>1.6.17</version>
+        <version>1.6.18</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/generated-platform-project/quarkus-blaze-persistence/integration-tests/blaze-persistence-examples-quarkus-3-testsuite-base/pom.xml
+++ b/generated-platform-project/quarkus-blaze-persistence/integration-tests/blaze-persistence-examples-quarkus-3-testsuite-base/pom.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkus.platform</groupId>
@@ -45,7 +43,8 @@
     </dependency>
     <dependency>
       <groupId>com.blazebit</groupId>
-      <artifactId>blaze-persistence-integration-hibernate-7.1</artifactId>
+      <artifactId>blaze-persistence-integration-hibernate-7.2</artifactId>
+      <version>${quarkus-blaze-persistence.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -393,22 +393,22 @@
       <dependency>
         <groupId>com.blazebit</groupId>
         <artifactId>blaze-persistence-entity-view-processor-jakarta</artifactId>
-        <version>1.6.17</version>
+        <version>1.6.18</version>
       </dependency>
       <dependency>
         <groupId>com.blazebit</groupId>
-        <artifactId>blaze-persistence-integration-hibernate-7.1</artifactId>
-        <version>1.6.17</version>
+        <artifactId>blaze-persistence-integration-hibernate-7.2</artifactId>
+        <version>1.6.18</version>
       </dependency>
       <dependency>
         <groupId>com.blazebit</groupId>
         <artifactId>blaze-persistence-integration-quarkus-3-deployment</artifactId>
-        <version>1.6.17</version>
+        <version>1.6.18</version>
       </dependency>
       <dependency>
         <groupId>com.blazebit</groupId>
         <artifactId>blaze-persistence-integration-quarkus-3</artifactId>
-        <version>1.6.17</version>
+        <version>1.6.18</version>
       </dependency>
       <dependency>
         <groupId>com.cronutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <quarkus-qpid-jms-tests.version>${quarkus-qpid-jms.version}</quarkus-qpid-jms-tests.version>
         <quarkus-hazelcast-client.version>4.1.0</quarkus-hazelcast-client.version>
         <quarkus-debezium.version>3.5.0.Final</quarkus-debezium.version>
-        <quarkus-blaze-persistence.version>1.6.17</quarkus-blaze-persistence.version>
+        <quarkus-blaze-persistence.version>1.6.18</quarkus-blaze-persistence.version>
         <quarkus-cassandra-client.version>1.4.1</quarkus-cassandra-client.version>
         <quarkus-cassandra-client-test.version>${quarkus-cassandra-client.version}</quarkus-cassandra-client-test.version>
         <quarkus-qute-web.version>3.4.5</quarkus-qute-web.version>
@@ -564,7 +564,7 @@
                                         <dependency>com.blazebit:blaze-persistence-integration-quarkus-3:${quarkus-blaze-persistence.version}</dependency>
                                         <dependency>com.blazebit:blaze-persistence-integration-quarkus-3-deployment:${quarkus-blaze-persistence.version}</dependency>
                                         <dependency>com.blazebit:blaze-persistence-entity-view-processor-jakarta:${quarkus-blaze-persistence.version}</dependency>
-                                        <dependency>com.blazebit:blaze-persistence-integration-hibernate-7.1:${quarkus-blaze-persistence.version}</dependency>
+                                        <dependency>com.blazebit:blaze-persistence-integration-hibernate-7.2:${quarkus-blaze-persistence.version}</dependency>
                                     </dependencyManagement>
                                     <release>
                                         <lastDetectedBomUpdate>io.quarkus.platform:quarkus-blaze-persistence-bom:3.28.0.CR1</lastDetectedBomUpdate>
@@ -585,6 +585,7 @@
                                             <skipNative>true</skipNative>
                                             <skipJvm>false</skipJvm>
                                             <artifact>com.blazebit:blaze-persistence-examples-quarkus-3-testsuite-base:${quarkus-blaze-persistence.version}</artifact>
+                                            <transformWith>${resourcesdir}/xslt/blaze-persistence-test-pom.xsl</transformWith>
                                             <systemProperties>
                                                 <quarkus.test.profile>h2</quarkus.test.profile>
                                             </systemProperties>

--- a/src/main/resources/xslt/blaze-persistence-test-pom.xsl
+++ b/src/main/resources/xslt/blaze-persistence-test-pom.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:pom="http://maven.apache.org/POM/4.0.0" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xalan="http://xml.apache.org/xslt" exclude-result-prefixes="pom xalan">
+
+    <xsl:output method="xml" indent="yes" xalan:indent-amount="2" />
+    <xsl:strip-space elements="*" />
+
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" />
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="/pom:project[pom:artifactId='blaze-persistence-examples-quarkus-3-testsuite-base']
+        /pom:dependencies/pom:dependency[pom:groupId='com.blazebit'
+        and pom:artifactId='blaze-persistence-integration-hibernate-7.1']/pom:artifactId">
+        <artifactId>blaze-persistence-integration-hibernate-7.2</artifactId>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
There was a problem with the property `hibernate.integration-version` in the upstream blaze-persistence-examples-quarkus-3-testsuite-base (sub)project. 

Therefore until blaze-persistence *1.6.19* is released I propose the `src/main/resources/xslt/blaze-persistence-test-pom.xsl` which fixes invalid `blaze-persistence-integration-hibernate-7.1` dependency pull while running `./mvnw -Dsync`.

Best,
Nikola