### PR TITLE
Fix claprun GitHub name to metacosm

### DIFF
--- a/.github/update-quarkus-platform.yml
+++ b/.github/update-quarkus-platform.yml
@@ -18,7 +18,7 @@ notifications:
   - member: MCPServer
     notify: [mkouba]
   - member: OperatorSDK
-    notify: [claprun, xstefank]
+    notify: [metacosm, xstefank]
   - member: Quarkus Flow
     notify: [ricardozanini, baldimir]
 


### PR DESCRIPTION
-