### PR TITLE
[3.33] Move quarkus-cxf-test-util-internal in camel-quarkus-integration-test-cxf-soap-grouped back to use correct property

### DIFF
--- a/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
+++ b/generated-platform-project/quarkus-camel/integration-tests/camel-quarkus-integration-test-cxf-soap-grouped/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.quarkiverse.cxf</groupId>
       <artifactId>quarkus-cxf-test-util-internal</artifactId>
-      <version>${quarkus.version}</version>
+      <version>${quarkus-cxf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
We (Quarkus QE) building custom platform for our testing. In last build we spotted failure when building platform for 3.33. In https://github.com/quarkusio/quarkus-platform/commit/9f12b59e0fb7e3e59e62d33d4956f7e21cc9a901#diff-405d042550bf01fefb20a9c7759b93fa0c37ca2eddcc3fce410c6f2d410b30f7L33 it was changed to hard coded version (where I don't see that much problem) and in https://github.com/quarkusio/quarkus-platform/commit/c17fb5cc52eace63bd13a0819de560c8552c4926#diff-405d042550bf01fefb20a9c7759b93fa0c37ca2eddcc3fce410c6f2d410b30f7L33 it was changed again but to `quarkus.version` which should not be. When we building with custom Quarkus version it failing to build as it can't find the   `quarkus-cxf-test-util-internal` with our custom Quarkus version (3.33.999-SNAPSHOT). 

I don't know if if the change in from `quarkus-cxf.version` was for some specific reason or not so atm I proposing go back to `quarkus-cxf.version`

cc @ppalaga @jmartisk as you are the one which updated this

Edit when I run the `./mvnw -Dsync` I see that this was overwritten back to `quarkus.version`
