### PR TITLE
[3.33] Upgrade to quarkus-platform-bom-generator to 0.0.132

### DIFF
--- a/generated-platform-project/quarkus-mcp-server/bom/pom.xml
+++ b/generated-platform-project/quarkus-mcp-server/bom/pom.xml
@@ -112,11 +112,6 @@
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.mcp</groupId>
-        <artifactId>quarkus-mcp-server-sse-parent</artifactId>
-        <version>1.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.mcp</groupId>
         <artifactId>quarkus-mcp-server-sse</artifactId>
         <version>1.10.6</version>
       </dependency>

--- a/generated-platform-project/quarkus-universe/bom/pom.xml
+++ b/generated-platform-project/quarkus-universe/bom/pom.xml
@@ -10590,11 +10590,6 @@
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.mcp</groupId>
-        <artifactId>quarkus-mcp-server-sse-parent</artifactId>
-        <version>1.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>io.quarkiverse.mcp</groupId>
         <artifactId>quarkus-mcp-server-sse</artifactId>
         <version>1.10.6</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <quarkus-langchain4j.version>1.7.6</quarkus-langchain4j.version>
         <quarkus-mcp-server.version>1.10.6</quarkus-mcp-server.version>
 
-        <quarkus-platform-bom-generator.version>0.0.129</quarkus-platform-bom-generator.version>
+        <quarkus-platform-bom-generator.version>0.0.132</quarkus-platform-bom-generator.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>


### PR DESCRIPTION
Upgrade the quarkus platform bom genetor version to 0.0.131 to be able to amange `integrates` metadatas.

I did not see any change on 0.0.130 that could be an issue but I could be wrong. Don't hesitate to comment if so.